### PR TITLE
support for find multiple, fixes #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ func (s *fixtureSource) FindAll(r api2go.Request) (interface{}, error) {
   // Return a slice of all posts as []Post
 }
 
-func (s *fixtureSource) FindOne(id string, r api2go.Request) (interface{}, error) {
+func (s *fixtureSource) FindOne(ID string, r api2go.Request) (interface{}, error) {
   // Return a single post by ID as Post
+}
+
+func (s *fixtureSource) FindMultiple(IDs string, r api2go.Request) (interface{}, error) {
+  // Return multiple posts by ID as []Post
+  // For example for Requests like GET /posts/1,2,3
 }
 
 func (s *fixtureSource) Create(obj interface{}) (string, error) {
@@ -77,6 +82,7 @@ POST    /v1/posts
 GET     /v1/posts/<id>
 PUT     /v1/posts/<id>
 DELETE  /v1/posts/<id>
+GET     /v1/posts/<id>,<id>,...
 ```
 
 #### Query Params

--- a/api.go
+++ b/api.go
@@ -21,7 +21,7 @@ type DataSource interface {
 	FindOne(ID string, req Request) (interface{}, error)
 
 	// FindMultiple returns all objects for the specified IDs
-	FindMultiple(IDs []string) (interface{}, error)
+	FindMultiple(IDs []string, req Request) (interface{}, error)
 
 	// Create a new object and return its ID
 	Create(interface{}) (string, error)
@@ -197,7 +197,7 @@ func (res *resource) handleRead(w http.ResponseWriter, r *http.Request, ps httpr
 	if len(ids) == 1 {
 		obj, err = res.source.FindOne(ids[0], buildRequest(r))
 	} else {
-		obj, err = res.source.FindMultiple(ids)
+		obj, err = res.source.FindMultiple(ids, buildRequest(r))
 	}
 
 	if err != nil {

--- a/api_test.go
+++ b/api_test.go
@@ -62,7 +62,7 @@ func (s *fixtureSource) FindOne(id string, req Request) (interface{}, error) {
 	return nil, NewHTTPError(nil, "post not found", http.StatusNotFound)
 }
 
-func (s *fixtureSource) FindMultiple(IDs []string) (interface{}, error) {
+func (s *fixtureSource) FindMultiple(IDs []string, req Request) (interface{}, error) {
 	var posts []Post
 
 	for _, id := range IDs {


### PR DESCRIPTION
this breaks the api again, but it is necessary.

The alternative to this would be calling `FindOne` multiple times for all the required IDs, but then the User cannot optimize his Data retrieval from the Database
