### PR TITLE
Unmarshal now supports a struct instead of only slice

### DIFF
--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -44,11 +44,18 @@ var _ = Describe("Unmarshal", func() {
 			},
 		}
 
-		It("unmarshals single objects", func() {
+		It("unmarshals single objects into a slice", func() {
 			var posts []SimplePost
 			err := Unmarshal(singlePostMap, &posts)
 			Expect(err).To(BeNil())
 			Expect(posts).To(Equal([]SimplePost{firstPost}))
+		})
+
+		It("unmarshals single objects into a struct", func() {
+			var post SimplePost
+			err := Unmarshal(singlePostMap, &post)
+			Expect(err).To(BeNil())
+			Expect(post).To(Equal(firstPost))
 		})
 
 		It("unmarshals multiple objects", func() {


### PR DESCRIPTION
Unmarshaling now works with a single struct as well. We used a slice before because in a previous specification it was possible to send multiple objects to the server. 

However, we will clean up the marshalling in ticket #111 

This resolves ticket #113 and also keeps in mind #112. From a clients perspective it would still be required to unmarshal into a slice because a server can send multiple objects inside a json. 

For now both is supported. If there are multiple objects in a json and the target is a struct, the first entry will be unmarshalled into it, and the rest is ignored. After #111 we should check that too and output an error. 