### PR TITLE
attributes object in data object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ go:
 install: 
   - go get -t -d -v ./...
   - go get github.com/onsi/ginkgo/ginkgo
+  - go get -u github.com/golang/lint/golint
 
 script:
   - ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --progress
+  - golint ./...
 
 notifications:
   slack:

--- a/api.go
+++ b/api.go
@@ -239,10 +239,12 @@ type ContentMarshaler interface {
 type JSONContentMarshaler struct {
 }
 
+// Marshal marshals with default JSON
 func (m JSONContentMarshaler) Marshal(i interface{}) ([]byte, error) {
 	return json.Marshal(i)
 }
 
+// Unmarshal with default JSON
 func (m JSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
 	return json.Unmarshal(data, i)
 }
@@ -250,7 +252,7 @@ func (m JSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
 // DefaultContentMarshalers is the default set of content marshalers for an API.
 // Currently this means handling application/vnd.api+json content type bodies
 // using the standard encoding/json package.
-var DefaultContentMarshalers map[string]ContentMarshaler = map[string]ContentMarshaler{
+var DefaultContentMarshalers = map[string]ContentMarshaler{
 	"application/vnd.api+json": JSONContentMarshaler{},
 }
 

--- a/examples/crud_example.go
+++ b/examples/crud_example.go
@@ -421,13 +421,15 @@ func (c *chocolateResource) Update(obj interface{}, r api2go.Request) error {
 	return c.storage.Update(choc)
 }
 
-type PrettyJSONContentMarshaler struct {
-}
+// PrettyJSONContentMarshaler for JSON in a human readable format
+type PrettyJSONContentMarshaler struct{}
 
+// Marshal marshals to pretty JSON
 func (m PrettyJSONContentMarshaler) Marshal(i interface{}) ([]byte, error) {
 	return json.MarshalIndent(i, "", "    ")
 }
 
+// Unmarshal the JSON
 func (m PrettyJSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
 	return json.Unmarshal(data, i)
 }

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Magic struct {
-	ID MagicID
+	ID MagicID `json:"-"`
 }
 
 func (m Magic) GetID() string {
@@ -45,7 +45,7 @@ func (c *Comment) SetID(stringID string) error {
 }
 
 type User struct {
-	ID       int
+	ID       int `json:"-"`
 	Name     string
 	Password string `json:"-"`
 }
@@ -66,9 +66,10 @@ func (u *User) SetID(stringID string) error {
 }
 
 type SimplePost struct {
-	ID, Title, Text string
-	Size            int
-	Created         time.Time `jsonapi:"name=create-date"`
+	ID          string `json:"-"`
+	Title, Text string
+	Size        int
+	Created     time.Time `jsonapi:"name=create-date"`
 }
 
 func (s SimplePost) GetID() string {
@@ -82,7 +83,7 @@ func (s *SimplePost) SetID(ID string) error {
 }
 
 type Post struct {
-	ID          int
+	ID          int `json:"-"`
 	Title       string
 	Comments    []Comment     `json:"-"`
 	CommentsIDs []int         `json:"-"`
@@ -208,7 +209,7 @@ func (c *Post) SetReferencedStructs(references []UnmarshalIdentifier) error {
 }
 
 type AnotherPost struct {
-	ID       int
+	ID       int   `json:"-"`
 	AuthorID int   `json:"-"`
 	Author   *User `json:"-"`
 }
@@ -237,7 +238,7 @@ func (p AnotherPost) GetReferencedIDs() []ReferenceID {
 }
 
 type ZeroPost struct {
-	ID    string
+	ID    string `json:"-"`
 	Title string
 	Value zero.Float
 }
@@ -247,7 +248,7 @@ func (z ZeroPost) GetID() string {
 }
 
 type ZeroPostPointer struct {
-	ID    string
+	ID    string `json:"-"`
 	Title string
 	Value *zero.Float
 }
@@ -257,7 +258,7 @@ func (z ZeroPostPointer) GetID() string {
 }
 
 type Question struct {
-	ID                  string
+	ID                  string `json:"-"`
 	Text                string
 	InspiringQuestionID sql.NullString `json:"-"`
 	InspiringQuestion   *Question      `json:"-"`
@@ -295,7 +296,7 @@ func (q Question) GetReferencedStructs() []MarshalIdentifier {
 }
 
 type Identity struct {
-	ID     int64    `json:"user_id"`
+	ID     int64    `json:"-"`
 	Scopes []string `json:"scopes"`
 }
 
@@ -313,7 +314,7 @@ func (u Unicorn) GetID() string {
 }
 
 type NumberPost struct {
-	ID             string
+	ID             string `json"-"`
 	Title          string
 	Number         int64
 	UnsignedNumber uint64
@@ -326,7 +327,7 @@ func (n *NumberPost) SetID(ID string) error {
 }
 
 type SqlNullPost struct {
-	ID     string
+	ID     string `json:"-"`
 	Title  zero.String
 	Likes  zero.Int
 	Rating zero.Float

--- a/jsonapi/integration_test.go
+++ b/jsonapi/integration_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Book struct {
-	ID       string
+	ID       string      `json:"-"`
 	Author   *StupidUser `json:"-"`
 	AuthorID string      `json:"-"`
 	Pages    []Page      `json:"-"`
@@ -84,7 +84,7 @@ func (b Book) GetReferencedStructs() []MarshalIdentifier {
 }
 
 type StupidUser struct {
-	ID   string
+	ID   string `json:"-"`
 	Name string
 }
 
@@ -93,7 +93,7 @@ func (s StupidUser) GetID() string {
 }
 
 type Page struct {
-	ID      string
+	ID      string `json:"-"`
 	Content string
 }
 
@@ -123,6 +123,7 @@ var _ = Describe("Test for the public api of this package", func() {
 		{ "data" : 
 			{ 
 				"id" : "TheOneAndOnlyID",
+				"attributes": {},
 				"links" : 
 				{ 
 						"author" : 
@@ -154,19 +155,31 @@ var _ = Describe("Test for the public api of this package", func() {
 			},
 			"included" : 
 				[ 
-					{ "id" : "A Magical UserID",
-						"name" : "Terry Pratchett",
+					{ 
+						"id" : "A Magical UserID",
+						"attributes": {
+							"name" : "Terry Pratchett"
+						},
 						"type" : "stupidUsers"
 					},
-					{ "content" : "First Page",
+					{ 
+						"attributes": {
+							"content" : "First Page"
+						},
 						"id" : "Page 1",
 						"type" : "pages"
 					},
-					{ "content" : "Second Page",
+					{ 
+						"attributes": {
+							"content" : "Second Page"
+						},
 						"id" : "Page 2",
 						"type" : "pages"
 					},
-					{ "content" : "Final page",
+					{ 
+						"attributes": {
+							"content" : "Final page"
+						},
 						"id" : "Page 3",
 						"type" : "pages"
 					}

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -199,13 +199,14 @@ func marshalData(element MarshalIdentifier, information ServerInformation) (map[
 
 	id := element.GetID()
 	content := getStructFields(element)
+	result["attributes"] = make(map[string]interface{})
+	attributes := result["attributes"].(map[string]interface{})
+	// if there is a field name `id` that is not ignored by the json ignore flag, it gets into the
+	// attributes as well, this is a intended behavior.
 	for k, v := range content {
-		result[k] = v
+		attributes[k] = v
 	}
 
-	// its important that the id from the interface
-	// gets added afterwards, otherwise an ID field
-	// could conflict with the actual marshalling
 	result["id"] = id
 	result["type"] = getStructType(element)
 

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -22,28 +22,34 @@ var _ = Describe("Marshalling", func() {
 			created, _ = time.Parse(time.RFC3339, "2014-11-10T16:30:48.823Z")
 			firstPost = SimplePost{ID: "first", Title: "First Post", Text: "Lipsum", Created: created}
 			firstPostMap = map[string]interface{}{
-				"type":        "simplePosts",
-				"id":          "first",
-				"title":       firstPost.Title,
-				"text":        firstPost.Text,
-				"size":        0,
-				"create-date": created,
+				"type": "simplePosts",
+				"id":   "first",
+				"attributes": map[string]interface{}{
+					"title":       firstPost.Title,
+					"text":        firstPost.Text,
+					"size":        0,
+					"create-date": created,
+				},
 			}
 
 			secondPost = SimplePost{ID: "second", Title: "Second Post", Text: "Getting more advanced!", Created: created}
 			secondPostMap = map[string]interface{}{
-				"type":        "simplePosts",
-				"id":          "second",
-				"title":       secondPost.Title,
-				"text":        secondPost.Text,
-				"size":        0,
-				"create-date": created,
+				"type": "simplePosts",
+				"id":   "second",
+				"attributes": map[string]interface{}{
+					"title":       secondPost.Title,
+					"text":        secondPost.Text,
+					"size":        0,
+					"create-date": created,
+				},
 			}
 
 			firstUserMap = map[string]interface{}{
 				"type": "users",
 				"id":   "100",
-				"name": "Nino",
+				"attributes": map[string]interface{}{
+					"name": "Nino",
+				},
 			}
 		})
 
@@ -79,8 +85,9 @@ var _ = Describe("Marshalling", func() {
 
 			expected := map[string]interface{}{
 				"data": map[string]interface{}{
-					"type": "magics",
-					"id":   "This should be visible",
+					"type":       "magics",
+					"id":         "This should be visible",
+					"attributes": map[string]interface{}{},
 				},
 			}
 
@@ -132,8 +139,10 @@ var _ = Describe("Marshalling", func() {
 					secondPostMap,
 					map[string]interface{}{
 						"id":   "1337",
-						"name": "Nino",
 						"type": "users",
+						"attributes": map[string]interface{}{
+							"name": "Nino",
+						},
 					},
 				},
 			}))
@@ -186,8 +195,10 @@ var _ = Describe("Marshalling", func() {
 								},
 							},
 						},
-						"title": "Foobar",
-						"type":  "posts",
+						"type": "posts",
+						"attributes": map[string]interface{}{
+							"title": "Foobar",
+						},
 					},
 					map[string]interface{}{
 						"id": "2",
@@ -215,25 +226,33 @@ var _ = Describe("Marshalling", func() {
 								},
 							},
 						},
-						"title": "Foobarbarbar",
-						"type":  "posts",
+						"type": "posts",
+						"attributes": map[string]interface{}{
+							"title": "Foobarbarbar",
+						},
 					},
 				},
 				"included": []map[string]interface{}{
 					map[string]interface{}{
 						"id":   "1",
-						"name": "Test Author",
 						"type": "users",
+						"attributes": map[string]interface{}{
+							"name": "Test Author",
+						},
 					},
 					map[string]interface{}{
 						"id":   "1",
-						"text": "First!",
 						"type": "comments",
+						"attributes": map[string]interface{}{
+							"text": "First!",
+						},
 					},
 					map[string]interface{}{
 						"id":   "2",
-						"text": "Second!",
 						"type": "comments",
+						"attributes": map[string]interface{}{
+							"text": "Second!",
+						},
 					},
 				},
 			}
@@ -246,9 +265,11 @@ var _ = Describe("Marshalling", func() {
 			i, err := MarshalWithURLs(post, CompleteServerInformation{})
 			expected := map[string]interface{}{
 				"data": map[string]interface{}{
-					"id":    "1",
-					"type":  "posts",
-					"title": "",
+					"id":   "1",
+					"type": "posts",
+					"attributes": map[string]interface{}{
+						"title": "",
+					},
 					"links": map[string]map[string]interface{}{
 						"comments": map[string]interface{}{
 							"self":    completePrefix + "/posts/1/links/comments",
@@ -280,9 +301,11 @@ var _ = Describe("Marshalling", func() {
 			Expect(err).To(BeNil())
 			Expect(i).To(Equal(map[string]interface{}{
 				"data": map[string]interface{}{
-					"id":    "1",
-					"type":  "posts",
-					"title": "",
+					"id":   "1",
+					"type": "posts",
+					"attributes": map[string]interface{}{
+						"title": "",
+					},
 					"links": map[string]map[string]interface{}{
 						"comments": map[string]interface{}{
 							"linkage": []map[string]interface{}{
@@ -304,12 +327,16 @@ var _ = Describe("Marshalling", func() {
 					map[string]interface{}{
 						"id":   "1",
 						"type": "users",
-						"name": "Tester",
+						"attributes": map[string]interface{}{
+							"name": "Tester",
+						},
 					},
 					map[string]interface{}{
 						"id":   "1",
 						"type": "comments",
-						"text": "",
+						"attributes": map[string]interface{}{
+							"text": "",
+						},
 					},
 				},
 			}))
@@ -321,8 +348,9 @@ var _ = Describe("Marshalling", func() {
 			Expect(err).To(BeNil())
 			Expect(i).To(Equal(map[string]interface{}{
 				"data": map[string]interface{}{
-					"id":   "1",
-					"type": "anotherPosts",
+					"id":         "1",
+					"type":       "anotherPosts",
+					"attributes": map[string]interface{}{},
 					"links": map[string]map[string]interface{}{
 						"author": map[string]interface{}{
 							"linkage": map[string]interface{}{
@@ -344,10 +372,12 @@ var _ = Describe("Marshalling", func() {
 		It("correctly unmarshals driver values", func() {
 			postMap := map[string]interface{}{
 				"data": map[string]interface{}{
-					"id":    "1",
-					"type":  "zeroPosts",
-					"title": "test",
-					"value": theFloat,
+					"id":   "1",
+					"type": "zeroPosts",
+					"attributes": map[string]interface{}{
+						"title": "test",
+						"value": theFloat,
+					},
 				},
 			}
 
@@ -358,7 +388,16 @@ var _ = Describe("Marshalling", func() {
 		})
 
 		It("correctly unmarshals into json", func() {
-			expectedJSON := []byte(`{"data":{"id":"1","type":"zeroPosts","title":"test","value":2.3}}`)
+			expectedJSON := []byte(`
+				{"data":{
+					"id":"1",
+					"type":"zeroPosts",
+					"attributes": {
+						"title":"test",
+						"value":2.3
+					}
+				}}
+			`)
 
 			json, err := MarshalToJSON(post)
 			Expect(err).To(BeNil())
@@ -368,10 +407,12 @@ var _ = Describe("Marshalling", func() {
 		It("correctly unmarshals driver values with pointer", func() {
 			postMap := map[string]interface{}{
 				"data": map[string]interface{}{
-					"id":    "1",
-					"type":  "zeroPostPointers",
-					"title": "test",
-					"value": &theFloat,
+					"id":   "1",
+					"type": "zeroPostPointers",
+					"attributes": map[string]interface{}{
+						"title": "test",
+						"value": &theFloat,
+					},
 				},
 			}
 
@@ -382,7 +423,16 @@ var _ = Describe("Marshalling", func() {
 		})
 
 		It("correctly unmarshals with pointer into json", func() {
-			expectedJSON := []byte(`{"data":{"id":"1","type":"zeroPostPointers","title":"test","value":2.3}}`)
+			expectedJSON := []byte(`
+				{"data":{
+					"id":"1",
+					"type":"zeroPostPointers",
+					"attributes": {
+						"title":"test",
+						"value":2.3
+					}
+				}}
+			`)
 
 			json, err := MarshalToJSON(pointerPost)
 			Expect(err).To(BeNil())
@@ -401,7 +451,9 @@ var _ = Describe("Marshalling", func() {
 				"data": map[string]interface{}{
 					"id":   "2",
 					"type": "questions",
-					"text": "Will it ever work?",
+					"attributes": map[string]interface{}{
+						"text": "Will it ever work?",
+					},
 					"links": map[string]map[string]interface{}{
 						"inspiringQuestion": map[string]interface{}{
 							"linkage": map[string]interface{}{
@@ -415,7 +467,9 @@ var _ = Describe("Marshalling", func() {
 					map[string]interface{}{
 						"id":   "1",
 						"type": "questions",
-						"text": "Does this test work?",
+						"attributes": map[string]interface{}{
+							"text": "Does this test work?",
+						},
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
 								"linkage": nil,
@@ -436,7 +490,9 @@ var _ = Describe("Marshalling", func() {
 					map[string]interface{}{
 						"id":   "3",
 						"type": "questions",
-						"text": "It works now",
+						"attributes": map[string]interface{}{
+							"text": "It works now",
+						},
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
 								"linkage": map[string]interface{}{
@@ -449,7 +505,9 @@ var _ = Describe("Marshalling", func() {
 					map[string]interface{}{
 						"id":   "2",
 						"type": "questions",
-						"text": "Will it ever work?",
+						"attributes": map[string]interface{}{
+							"text": "Will it ever work?",
+						},
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
 								"linkage": map[string]interface{}{
@@ -464,7 +522,9 @@ var _ = Describe("Marshalling", func() {
 					map[string]interface{}{
 						"id":   "1",
 						"type": "questions",
-						"text": "Does this test work?",
+						"attributes": map[string]interface{}{
+							"text": "Does this test work?",
+						},
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
 								"linkage": nil,
@@ -486,8 +546,10 @@ var _ = Describe("Marshalling", func() {
 				"data": map[string]interface{}{
 					"id":   "1234",
 					"type": "identities",
-					"scopes": []string{
-						"user_global",
+					"attributes": map[string]interface{}{
+						"scopes": []string{
+							"user_global",
+						},
 					},
 				},
 			}
@@ -500,11 +562,13 @@ var _ = Describe("Marshalling", func() {
 		It("Marshalls correctly without an ID field", func() {
 			expected := map[string]interface{}{
 				"data": map[string]interface{}{
-					"id":        "magicalUnicorn",
-					"unicornID": int64(1234),
-					"type":      "unicorns",
-					"scopes": []string{
-						"user_global",
+					"id":   "magicalUnicorn",
+					"type": "unicorns",
+					"attributes": map[string]interface{}{
+						"scopes": []string{
+							"user_global",
+						},
+						"unicornID": int64(1234),
 					},
 				},
 			}
@@ -673,11 +737,13 @@ var _ = Describe("Marshalling", func() {
 				{
 					"data": {
 						"id": "theID",
-						"title": "Test",
-						"likes": 666,
-						"rating": 66.66,
-						"isCool": true,
-						"type": "sqlNullPosts"
+						"type": "sqlNullPosts",
+						"attributes": {
+							"title": "Test",
+							"likes": 666,
+							"rating": 66.66,
+							"isCool": true
+						}
 					}
 				}
 			`))

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -13,33 +13,39 @@ import (
 var _ = Describe("Unmarshal", func() {
 	Context("When unmarshaling simple objects", func() {
 		t, _ := time.Parse(time.RFC3339, "2014-11-10T16:30:48.823Z")
-		singleJSON := []byte(`{"data":{"id": "1", "type": "simplePosts", "title":"First Post","text":"Lipsum", "Created": "2014-11-10T16:30:48.823Z"}}`)
+		singleJSON := []byte(`{"data":{"id": "1", "type": "simplePosts", "attributes": {"title":"First Post","text":"Lipsum", "Created": "2014-11-10T16:30:48.823Z"}}}`)
 		firstPost := SimplePost{ID: "1", Title: "First Post", Text: "Lipsum", Created: t}
 		secondPost := SimplePost{ID: "2", Title: "Second Post", Text: "Foobar!", Created: t}
 		singlePostMap := map[string]interface{}{
 			"data": map[string]interface{}{
-				"id":          "1",
-				"type":        "simplePosts",
-				"title":       firstPost.Title,
-				"text":        firstPost.Text,
-				"create-date": "2014-11-10T16:30:48.823Z",
+				"id":   "1",
+				"type": "simplePosts",
+				"attributes": map[string]interface{}{
+					"title":       firstPost.Title,
+					"text":        firstPost.Text,
+					"create-date": "2014-11-10T16:30:48.823Z",
+				},
 			},
 		}
 		multiplePostMap := map[string]interface{}{
 			"data": []interface{}{
 				map[string]interface{}{
-					"id":          "1",
-					"type":        "simplePosts",
-					"title":       firstPost.Title,
-					"text":        firstPost.Text,
-					"create-date": "2014-11-10T16:30:48.823Z",
+					"id":   "1",
+					"type": "simplePosts",
+					"attributes": map[string]interface{}{
+						"title":       firstPost.Title,
+						"text":        firstPost.Text,
+						"create-date": "2014-11-10T16:30:48.823Z",
+					},
 				},
 				map[string]interface{}{
-					"id":          "2",
-					"type":        "simplePosts",
-					"title":       secondPost.Title,
-					"text":        secondPost.Text,
-					"create-date": "2014-11-10T16:30:48.823Z",
+					"id":   "2",
+					"type": "simplePosts",
+					"attributes": map[string]interface{}{
+						"title":       secondPost.Title,
+						"text":        secondPost.Text,
+						"create-date": "2014-11-10T16:30:48.823Z",
+					},
 				},
 			},
 		}
@@ -47,7 +53,7 @@ var _ = Describe("Unmarshal", func() {
 		It("unmarshals single objects into a slice", func() {
 			var posts []SimplePost
 			err := Unmarshal(singlePostMap, &posts)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(posts).To(Equal([]SimplePost{firstPost}))
 		})
 
@@ -110,20 +116,20 @@ var _ = Describe("Unmarshal", func() {
 		It("errors with wrong keys", func() {
 			var posts []SimplePost
 			err := Unmarshal(map[string]interface{}{
-				"data": []interface{}{
-					map[string]interface{}{
+				"data": map[string]interface{}{
+					"attributes": map[string]interface{}{
 						"foobar": 42,
 					},
 				},
 			}, &posts)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("errors with wrong type, expected int, got a string", func() {
 			var posts []SimplePost
 			err := Unmarshal(map[string]interface{}{
-				"data": []interface{}{
-					map[string]interface{}{
+				"data": map[string]interface{}{
+					"attributes": map[string]interface{}{
 						"text": "Gopher",
 						"size": "blubb",
 					},
@@ -136,10 +142,10 @@ var _ = Describe("Unmarshal", func() {
 		It("errors with invalid time format", func() {
 			t, err := time.Parse(time.RFC3339, "2014-11-10T16:30:48.823Z")
 			faultyPostMap := map[string]interface{}{
-				"data": []interface{}{
-					map[string]interface{}{
-						"id":      "1",
-						"type":    "simplePosts",
+				"data": map[string]interface{}{
+					"id":   "1",
+					"type": "simplePosts",
+					"attributes": map[string]interface{}{
 						"title":   firstPost.Title,
 						"text":    firstPost.Text,
 						"created": t.Format(time.RFC1123Z),
@@ -235,9 +241,11 @@ var _ = Describe("Unmarshal", func() {
 			postMap := map[string]interface{}{
 				"data": []interface{}{
 					map[string]interface{}{
-						"id":    "1",
-						"type":  "posts",
-						"title": "Test",
+						"id":   "1",
+						"type": "posts",
+						"attributes": map[string]interface{}{
+							"title": "Test",
+						},
 						"links": map[string]interface{}{
 							"author": map[string]interface{}{
 								"linkage": map[string]interface{}{
@@ -260,9 +268,11 @@ var _ = Describe("Unmarshal", func() {
 			postMap := map[string]interface{}{
 				"data": []interface{}{
 					map[string]interface{}{
-						"id":    "3",
-						"type":  "posts",
-						"title": "Test",
+						"id":   "3",
+						"type": "posts",
+						"attributes": map[string]interface{}{
+							"title": "Test",
+						},
 						"links": map[string]interface{}{
 							"author": map[string]interface{}{
 								"linkage": map[string]interface{}{
@@ -297,9 +307,11 @@ var _ = Describe("Unmarshal", func() {
 			postMap := map[string]interface{}{
 				"data": []interface{}{
 					map[string]interface{}{
-						"id":    "1",
-						"type":  "posts",
-						"title": "Test",
+						"id":   "1",
+						"type": "posts",
+						"attributes": map[string]interface{}{
+							"title": "Test",
+						},
 					},
 				},
 			}
@@ -331,9 +343,11 @@ var _ = Describe("Unmarshal", func() {
 			postMap := map[string]interface{}{
 				"data": []interface{}{
 					map[string]interface{}{
-						"id":    "1",
-						"type":  "posts",
-						"title": "New Title",
+						"id":   "1",
+						"type": "posts",
+						"attributes": map[string]interface{}{
+							"title": "New Title",
+						},
 					},
 				},
 			}
@@ -350,10 +364,12 @@ var _ = Describe("Unmarshal", func() {
 			postMap := map[string]interface{}{
 				"data": []interface{}{
 					map[string]interface{}{
-						"id":    "1",
-						"type":  "simplePosts",
-						"title": "Nice Title",
-						"text":  nil,
+						"id":   "1",
+						"type": "simplePosts",
+						"attributes": map[string]interface{}{
+							"title": "Nice Title",
+							"text":  nil,
+						},
 					},
 				},
 			}
@@ -370,8 +386,10 @@ var _ = Describe("Unmarshal", func() {
 			postMap := map[string]interface{}{
 				"data": []interface{}{
 					map[string]interface{}{
-						"title": "Nice Title",
-						"type":  "simplePosts",
+						"type": "simplePosts",
+						"attributes": map[string]interface{}{
+							"title": "Nice Title",
+						},
 					},
 				},
 			}
@@ -389,9 +407,11 @@ var _ = Describe("Unmarshal", func() {
 					"data": [
 						{
 							"id": "test",
-							"title": "Blubb",
-							"number": 1337,
-							"type": "numberPosts"
+							"type": "numberPosts",
+							"attributes": {
+								"title": "Blubb",
+								"number": 1337
+							}
 						}
 					]
 				}
@@ -411,9 +431,11 @@ var _ = Describe("Unmarshal", func() {
 					"data": [
 						{
 							"id": "test",
-							"title": "Blubb",
-							"number": -1337,
-							"type": "numberPosts"
+							"type": "numberPosts",
+							"attributes": {
+								"title": "Blubb",
+								"number": -1337
+							}
 						}
 					]
 				}
@@ -433,9 +455,11 @@ var _ = Describe("Unmarshal", func() {
 					"data": [
 						{
 							"id": "test",
-							"title": "Blubb",
-							"unsignedNumber": 1337,
-							"type": "numberPosts"
+							"type": "numberPosts",
+							"attributes": {
+								"title": "Blubb",
+								"unsignedNumber": 1337
+							}
 						}
 					]
 				}
@@ -462,11 +486,13 @@ var _ = Describe("Unmarshal", func() {
 				{
 					"data": {
 						"id": "theID",
-						"title": "Test",
-						"likes": 666,
-						"rating": 66.66,
-						"isCool": true,
-						"type": "sqlNullPosts"
+						"type": "sqlNullPosts",
+						"attributes": {
+							"title": "Test",
+							"likes": 666,
+							"rating": 66.66,
+							"isCool": true
+						}
 					}
 				}
 			`), &nullPosts)


### PR DESCRIPTION
This is a necessary change for v 1.0

All struct payload now is in an `attributes` sub-object inside the `data` object of the json.

This resolves #118 