### PR TITLE
allow client generated IDs #127

### DIFF
--- a/api.go
+++ b/api.go
@@ -619,19 +619,6 @@ func (res *resource) handleCreate(w http.ResponseWriter, r *http.Request, prefix
 	//TODO create multiple objects not only one.
 	newObj := newObjs.Index(0).Interface()
 
-	checkID, ok := newObj.(jsonapi.MarshalIdentifier)
-	if ok {
-		if checkID.GetID() != "" {
-			err := Error{
-				Status: string(http.StatusForbidden),
-				Title:  "Forbidden",
-				Detail: "Client generated IDs are not supported.",
-			}
-
-			return respondWith(err, info, http.StatusForbidden, w, r, res.marshalers)
-		}
-	}
-
 	id, err := res.source.Create(newObj, buildRequest(r))
 	if err != nil {
 		return err

--- a/api_test.go
+++ b/api_test.go
@@ -658,12 +658,11 @@ var _ = Describe("RestHandler", func() {
 		})
 
 		It("POSTSs with client id", func() {
-			reqBody := strings.NewReader(`{"data": [{"id" : "100", "title": "New Post", "type": "posts"}]}`)
+			reqBody := strings.NewReader(`{"data": [{"attributes": {"title": "New Post"}, "id": "100", "type": "posts"}]}`)
 			req, err := http.NewRequest("POST", "/v1/posts", reqBody)
 			Expect(err).To(BeNil())
 			api.Handler().ServeHTTP(rec, req)
-			Expect(rec.Code).To(Equal(http.StatusForbidden))
-			Expect(rec.Body).To(ContainSubstring("Client generated IDs are not supported."))
+			Expect(rec.Code).To(Equal(http.StatusCreated))
 		})
 
 		It("POSTSs new objects with trailing slash automatic redirect disabled", func() {


### PR DESCRIPTION
This fixes #127 

A user now has to check in a resources `Create` method whether he can accept the ID that a client send or not. 