### PR TITLE
fix a bug with multiple relationships of the same type

### DIFF
--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -226,7 +226,7 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 	relationships := make(map[string]map[string]interface{})
 
 	for _, referenceID := range referencedIDs {
-		sortedResults[referenceID.Type] = append(sortedResults[referenceID.Type], referenceID)
+		sortedResults[referenceID.Name] = append(sortedResults[referenceID.Name], referenceID)
 	}
 
 	references := relationer.GetReferences()
@@ -237,8 +237,8 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 		notIncludedReferences[reference.Name] = reference
 	}
 
-	for referenceType, referenceIDs := range sortedResults {
-		name := referenceIDs[0].Name
+	for name, referenceIDs := range sortedResults {
+		referenceType := referenceIDs[0].Type
 		relationships[name] = map[string]interface{}{}
 		// if referenceType is plural, we need to use an array for data, otherwise it's just an object
 		if Pluralize(name) == name {

--- a/jsonapi/marshal_same_type_test.go
+++ b/jsonapi/marshal_same_type_test.go
@@ -1,0 +1,115 @@
+package jsonapi
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type Node struct {
+	ID                string `json:"-"`
+	Content           string
+	MotherID          string   `json:"-"`
+	ChildIDs          []string `json:"-"`
+	AbandonedChildIDs []string `json:"-"`
+}
+
+func (n *Node) GetID() string {
+	return n.ID
+}
+
+func (n *Node) GetReferences() []Reference {
+	return []Reference{
+		{
+			Type: "nodes",
+			Name: "mother-node",
+		},
+		{
+			Type: "nodes",
+			Name: "child-nodes",
+		},
+		{
+			Type: "nodes",
+			Name: "abandoned-child-nodes",
+		},
+	}
+}
+
+func (n *Node) GetReferencedIDs() []ReferenceID {
+	result := []ReferenceID{}
+
+	if n.MotherID != "" {
+		result = append(result, ReferenceID{Type: "nodes", Name: "mother-node", ID: n.MotherID})
+	}
+
+	for _, referenceID := range n.ChildIDs {
+		result = append(result, ReferenceID{Type: "nodes", Name: "child-nodes", ID: referenceID})
+	}
+
+	for _, referenceID := range n.AbandonedChildIDs {
+		result = append(result, ReferenceID{Type: "nodes", Name: "abandoned-child-nodes", ID: referenceID})
+	}
+
+	return result
+}
+
+var _ = Describe("Marshalling with the same reference type", func() {
+	var (
+		theNode Node
+	)
+
+	BeforeEach(func() {
+		theNode = Node{
+			ID:                "super",
+			Content:           "I am the Super Node",
+			MotherID:          "1337",
+			ChildIDs:          []string{"666", "42"},
+			AbandonedChildIDs: []string{"2", "1"},
+		}
+	})
+
+	It("marshals all the relationships of the same type", func() {
+		i, err := Marshal(&theNode)
+		Expect(err).To(BeNil())
+		Expect(i).To(Equal(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":   "super",
+				"type": "nodes",
+				"attributes": map[string]interface{}{
+					"content": "I am the Super Node",
+				},
+				"relationships": map[string]map[string]interface{}{
+					"mother-node": map[string]interface{}{
+						"data": map[string]interface{}{
+							"type": "nodes",
+							"id":   "1337",
+						},
+					},
+					"child-nodes": map[string]interface{}{
+						"data": []map[string]interface{}{
+							{
+								"type": "nodes",
+								"id":   "666",
+							},
+							{
+								"type": "nodes",
+								"id":   "42",
+							},
+						},
+					},
+					"abandoned-child-nodes": map[string]interface{}{
+						"data": []map[string]interface{}{
+							{
+								"type": "nodes",
+								"id":   "2",
+							},
+							{
+								"type": "nodes",
+								"id":   "1",
+							},
+						},
+					},
+				},
+			},
+		}))
+	})
+})


### PR DESCRIPTION
because of a wrong sorting after "type" in marshal.go so me references were
skipped and not correctly marshalled. The unique key that must be used is the
name, not the type because it is possible to have multiple references of the
same type, but with a different name.