### PR TITLE
new feature to rename a struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ go get github.com/manyminds/api2go/jsonapi
 ## TOC
 - [Examples](#examples)
 - [Interfaces to implement](#interfaces-to-implement)
+  - [EntityNamer](#entitynamer)
   - [MarshalIdentifier](#marshalidentifier)
   - [UnmarshalIdentifier](#unmarshalidentifier)
   - [Marshalling with References to other structs](#marshalling-with-references-to-other-structs)
@@ -68,6 +69,34 @@ json ignore tag. Api2go will use the `GetID` method that you implemented for you
 
 In order to use different internal names for elements, you can specify a jsonapi tag. The api will marshal results now with the name in the tag.
 Create/Update/Delete works accordingly, but will fallback to the internal value as well if possible.
+
+### EntityNamer
+```go
+type EntityNamer interface {
+	GetName() string
+}
+```
+
+This is an interface which can be implemented optionally. Normally, the name of
+a struct will be automatically generated in it's plural form. For example if
+your struct has the type `Post`, it's generated name is `posts`. And the url
+for the GET request for post with ID 1 would be `/posts/1`.
+
+If you implement the `GetName()` method and it returns `special-posts`, then
+this would be the name in the `type` field of the generated json and also the
+name for the generated routes.
+
+Currently, you must implement this interface, if you have a struct type that
+consists of multiple words and you want to use a **hyphenized** name. For example `UnicornPost`.
+Our default Jsonifier would then generate the name `unicornPosts`. But if you
+want the [recommended](http://jsonapi.org/recommendations/#naming) name, you
+have to implement `GetName`
+
+```go
+func (s UnicornPost) GetName() string {
+	return "unicorn-posts"
+}
+```
 
 ### MarshalIdentifier
 ```go

--- a/api.go
+++ b/api.go
@@ -315,7 +315,13 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		name = resourceType.Elem().Name()
 	}
 
-	name = jsonapi.Jsonify(jsonapi.Pluralize(name))
+	// check if EntityNamer interface is implemented and use that as name
+	entityName, ok := prototype.(jsonapi.EntityNamer)
+	if ok {
+		name = entityName.GetName()
+	} else {
+		name = jsonapi.Jsonify(jsonapi.Pluralize(name))
+	}
 
 	res := resource{
 		resourceType: resourceType,

--- a/api_entity_name_test.go
+++ b/api_entity_name_test.go
@@ -1,0 +1,135 @@
+package api2go
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type BaguetteTaste struct {
+	ID    string `json:"-"`
+	Taste string
+}
+
+func (s BaguetteTaste) GetID() string {
+	return s.ID
+}
+
+func (s *BaguetteTaste) SetID(ID string) error {
+	s.ID = ID
+	return nil
+}
+
+func (s BaguetteTaste) GetName() string {
+	return "baguette-tastes"
+}
+
+type BaguetteResource struct{}
+
+func (s BaguetteResource) FindOne(ID string, req Request) (interface{}, error) {
+	return BaguetteTaste{ID: "blubb", Taste: "Very Bad"}, nil
+}
+
+func (s BaguetteResource) FindAll(req Request) (interface{}, error) {
+	return []BaguetteTaste{
+		{
+			ID:    "1",
+			Taste: "Very Good",
+		},
+		{
+			ID:    "2",
+			Taste: "Very Bad",
+		},
+	}, nil
+}
+
+func (s BaguetteResource) Create(obj interface{}, req Request) (string, error) {
+	return "newID", nil
+}
+
+func (s BaguetteResource) Delete(ID string, req Request) error {
+	return nil
+}
+
+func (s BaguetteResource) Update(obj interface{}, req Request) error {
+	return nil
+}
+
+var _ = Describe("Test route renaming with EntityNamer interface", func() {
+	var (
+		api  *API
+		rec  *httptest.ResponseRecorder
+		body *strings.Reader
+	)
+	BeforeEach(func() {
+		api = NewAPI("v1")
+		api.AddResource(BaguetteTaste{}, BaguetteResource{})
+		rec = httptest.NewRecorder()
+		body = strings.NewReader(`
+		{
+			"data": {
+				"attributes": {
+					"taste": "smells awful"
+				},
+				"id": "blubb",
+				"type": "baguette-tastes"
+			}
+		}
+		`)
+	})
+
+	// check that renaming works, we do not test every single route here, the name variable is used
+	// for each route, we just check the 5 basic ones. Marshalling and Unmarshalling is tested with
+	// this again too.
+	It("FindAll returns 200", func() {
+		req, err := http.NewRequest("GET", "/v1/baguette-tastes", nil)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("FindOne", func() {
+		req, err := http.NewRequest("GET", "/v1/baguette-tastes/12345", nil)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("Delete", func() {
+		req, err := http.NewRequest("DELETE", "/v1/baguette-tastes/12345", nil)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusNoContent))
+	})
+
+	It("Create", func() {
+		req, err := http.NewRequest("POST", "/v1/baguette-tastes", body)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		// the response is always the one record returned by FindOne, the implementation does not
+		// check the ID here and returns something new ...
+		Expect(rec.Body.String()).To(MatchJSON(`
+		{
+			"data": {
+				"attributes": {
+					"taste":"Very Bad"
+				},
+				"id":"blubb",
+				"type":"baguette-tastes"
+				}
+			}
+		`))
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+	})
+
+	It("Update", func() {
+		req, err := http.NewRequest("PATCH", "/v1/baguette-tastes/blubb", body)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Body.String()).To(Equal(""))
+		Expect(rec.Code).To(Equal(http.StatusNoContent))
+	})
+})

--- a/jsonapi/entity_namer.go
+++ b/jsonapi/entity_namer.go
@@ -1,0 +1,7 @@
+package jsonapi
+
+// The EntityNamer interface can be opionally implemented to rename a struct. The name returned by
+// GetName will be used for the route generation as well as the "type" field in all responses
+type EntityNamer interface {
+	GetName() string
+}

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -343,6 +343,18 @@ func (s *SqlNullPost) SetID(ID string) error {
 	return nil
 }
 
+type RenamedComment struct {
+	Data string
+}
+
+func (r RenamedComment) GetID() string {
+	return "666"
+}
+
+func (r RenamedComment) GetName() string {
+	return "renamed-comments"
+}
+
 type CompleteServerInformation struct{}
 
 const completePrefix = "http://my.domain/v1"

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -358,6 +358,11 @@ func marshalStruct(data MarshalIdentifier, information ServerInformation) (map[s
 }
 
 func getStructType(data MarshalIdentifier) string {
+	entityName, ok := data.(EntityNamer)
+	if ok {
+		return entityName.GetName()
+	}
+
 	reflectType := reflect.TypeOf(data)
 	if reflectType.Kind() == reflect.Ptr {
 		return Pluralize(Jsonify(reflectType.Elem().Name()))

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -602,6 +602,11 @@ var _ = Describe("Marshalling", func() {
 			result := getStructType(&comment)
 			Expect(result).To(Equal("comments"))
 		})
+
+		It("checks for EntityNamer interface", func() {
+			result := getStructType(RenamedComment{"something"})
+			Expect(result).To(Equal("renamed-comments"))
+		})
 	})
 
 	Context("test getStructFields method", func() {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -229,12 +229,18 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 				targetStruct.SetID(id)
 
 			case "type":
+				var expectedType string
 				structType, ok := v.(string)
 				if !ok {
 					return errors.New("type must be string")
 				}
 
-				expectedType := Pluralize(Jsonify(targetStructType.Name()))
+				entityName, ok := val.Interface().(EntityNamer)
+				if ok {
+					expectedType = entityName.GetName()
+				} else {
+					expectedType = Pluralize(Jsonify(targetStructType.Name()))
+				}
 				if structType != expectedType {
 					return fmt.Errorf("type %s does not match expected type %s of target struct", structType, expectedType)
 				}


### PR DESCRIPTION
the current situation always generated the structs name from it's type. So
a UnicornPost struct would have the generated name `unicornPosts`. But maybe,
a user wants to use a different naming scheme, like `unicorn-posts`. This is
now possible.

Maybe we should change the Jsonify and Dejsonify methods in the future that
they automatically generate *hyphenized* names of everything.

This resolves #134 