### PR TITLE
Update api2go.Error structure to json api 1.0 spec

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -281,7 +281,7 @@ func (s *fixtureSource) Create(obj interface{}, req Request) (string, error) {
 
 	if p.Title == "" {
 		err := NewHTTPError(errors.New("Bad request."), "Bad Request", http.StatusBadRequest)
-		err.Errors = append(err.Errors, Error{ID: "SomeErrorID", Path: "Title"})
+		err.Errors = append(err.Errors, Error{ID: "SomeErrorID", Source: &ErrorSource{Pointer: "Title"}})
 		return "", err
 	}
 
@@ -620,7 +620,7 @@ var _ = Describe("RestHandler", func() {
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			Expect(rec.Body.Bytes()).To(MatchJSON(`
 				{"data": {
-					"id": "1", 
+					"id": "1",
 					"type": "users",
 					"attributes": {
 						"name": "Dieter"
@@ -635,7 +635,7 @@ var _ = Describe("RestHandler", func() {
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			Expect(rec.Body.Bytes()).To(MatchJSON(`
 				{"data": [{
-					"id": "1", 
+					"id": "1",
 					"type": "comments",
 					"attributes": {
 						"value": "This is a stupid post!"
@@ -977,7 +977,7 @@ var _ = Describe("RestHandler", func() {
 			Expect(err).To(BeNil())
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusBadRequest))
-			expected := `{"errors":[{"id":"SomeErrorID","path":"Title"}]}`
+			expected := `{"errors":[{"id":"SomeErrorID","source":{"pointer":"Title"}}]}`
 			actual := strings.TrimSpace(string(rec.Body.Bytes()))
 			Expect(actual).To(Equal(expected))
 		})

--- a/error.go
+++ b/error.go
@@ -19,18 +19,39 @@ type HTTPError struct {
 //other semantical application problems
 //for more information see http://jsonapi.org/format/#errors
 type Error struct {
-	ID     string `json:"id,omitempty"`
-	Href   string `json:"href,omitempty"`
-	Status string `json:"status,omitempty"`
-	Code   string `json:"code,omitempty"`
-	Title  string `json:"title,omitempty"`
-	Detail string `json:"detail,omitempty"`
-	Path   string `json:"path,omitempty"`
+	ID     string       `json:"id,omitempty"`
+	Links  *ErrorLinks  `json:"links,omitempty"`
+	Status string       `json:"status,omitempty"`
+	Code   string       `json:"code,omitempty"`
+	Title  string       `json:"title,omitempty"`
+	Detail string       `json:"detail,omitempty"`
+	Source *ErrorSource `json:"source,omitempty"`
+	Meta   interface{}  `json:"meta,omitempty"`
 }
 
 // GetID returns the ID
 func (e Error) GetID() string {
 	return e.ID
+}
+
+//ErrorLinks is used to provide an About URL that leads to
+//further details about the particular occurrence of the problem.
+//
+//for more information see http://jsonapi.org/format/#error-objects
+type ErrorLinks struct {
+	About string `json:"about,omitempty"`
+}
+
+//ErrorSource is used to provide references to the source of an error.
+//
+//The Pointer is a JSON Pointer to the associated entity in the request
+//document.
+//The Paramter is a string indicating which query parameter caused the error.
+//
+//for more information see http://jsonapi.org/format/#error-objects
+type ErrorSource struct {
+	Pointer   string `json:"pointer,omitempty"`
+	Parameter string `json:"parameter,omitempty"`
 }
 
 //marshalError marshals all error types

--- a/error_test.go
+++ b/error_test.go
@@ -38,19 +38,47 @@ var _ = Describe("Errors test", func() {
 			httpErr := NewHTTPError(errors.New("Bad Request"), "Bad Request", 500)
 
 			errorOne := Error{
-				ID:     "001",
-				Href:   "http://bla/blub",
+				ID: "001",
+				Links: &ErrorLinks{
+					About: "http://bla/blub",
+				},
 				Status: "500",
 				Code:   "001",
 				Title:  "Title must not be empty",
 				Detail: "Never occures in real life",
-				Path:   "#titleField",
+				Source: &ErrorSource{
+					Pointer: "#titleField",
+				},
+				Meta: map[string]interface{}{
+					"creator": "api2go",
+				},
 			}
 
 			httpErr.Errors = append(httpErr.Errors, errorOne)
 
 			result := marshalError(httpErr, JSONContentMarshaler{})
-			expected := `{"errors":[{"id":"001","href":"http://bla/blub","status":"500","code":"001","title":"Title must not be empty","detail":"Never occures in real life","path":"#titleField"}]}`
+			expected := `{"errors":[{"id":"001","links":{"about":"http://bla/blub"},"status":"500","code":"001","title":"Title must not be empty","detail":"Never occures in real life","source":{"pointer":"#titleField"},"meta":{"creator":"api2go"}}]}`
+			Expect(result).To(Equal(expected))
+		})
+
+		It("will be marshalled correctly with child errors without links or source", func() {
+			httpErr := NewHTTPError(errors.New("Bad Request"), "Bad Request", 500)
+
+			errorOne := Error{
+				ID:     "001",
+				Status: "500",
+				Code:   "001",
+				Title:  "Title must not be empty",
+				Detail: "Never occures in real life",
+				Meta: map[string]interface{}{
+					"creator": "api2go",
+				},
+			}
+
+			httpErr.Errors = append(httpErr.Errors, errorOne)
+
+			result := marshalError(httpErr, JSONContentMarshaler{})
+			expected := `{"errors":[{"id":"001","status":"500","code":"001","title":"Title must not be empty","detail":"Never occures in real life","meta":{"creator":"api2go"}}]}`
 			Expect(result).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
The Href and Path fields have been removed. The Links, Source and Meta fields have been added.

To update existing code the Href should be changed to

    Links: api2go.ErrorLinks{About: "Href Value"},

the Path should be changed to

    Source: api2go.ErrorSource{Pointer: "Path Value"},

Refs #137 

`go test` is currently passing.