### PR TITLE
Replace slack notifications with gitter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,7 @@ script:
   - golint ./...
 
 notifications:
-  slack:
-    secure: OdP+maK3uhlYdaTjImPLnMeSxYcV2Kql/BjPW7uFzK4YVa2gkCDNqBGu8y4i47MbXCmXPutPOSOcIsjQ0Rgevr4fWjWBMXITqfZKF/UqrptIfQGP2T8LKm9TdhBCrtfW4EsBsTpOkgmQyWzihr0Zu1pwoeQ+HAesViuaSdriZGw=
+  webhooks:
+    urls: 
+      - https://webhooks.gitter.im/e/9caacfa1bede5e900019
+    on_success: change


### PR DESCRIPTION
Since we do not use slack anymore we could change notifications to our
public gitter chat.