### PR TITLE
Skip the `data` field for relations

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -83,12 +83,14 @@ func (s *SimplePost) SetID(ID string) error {
 }
 
 type Post struct {
-	ID          int `json:"-"`
-	Title       string
-	Comments    []Comment     `json:"-"`
-	CommentsIDs []int         `json:"-"`
-	Author      *User         `json:"-"`
-	AuthorID    sql.NullInt64 `json:"-"`
+	ID            int `json:"-"`
+	Title         string
+	Comments      []Comment     `json:"-"`
+	CommentsIDs   []int         `json:"-"`
+	CommentsEmpty bool          `json:"-"`
+	Author        *User         `json:"-"`
+	AuthorID      sql.NullInt64 `json:"-"`
+	AuthorEmpty   bool          `json:"-"`
 }
 
 func (c Post) GetID() string {
@@ -109,12 +111,14 @@ func (c *Post) SetID(stringID string) error {
 func (c Post) GetReferences() []Reference {
 	return []Reference{
 		{
-			Type: "comments",
-			Name: "comments",
+			Type:        "comments",
+			Name:        "comments",
+			IsNotLoaded: c.CommentsEmpty,
 		},
 		{
-			Type: "users",
-			Name: "author",
+			Type:        "users",
+			Name:        "author",
+			IsNotLoaded: c.AuthorEmpty,
 		},
 	}
 }

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -376,6 +376,104 @@ var _ = Describe("Marshalling", func() {
 		})
 	})
 
+	Context("when marshalling with relations that were not loaded", func() {
+		It("skips data field for not loaded relations", func() {
+			post := Post{ID: 123, Title: "Test", CommentsEmpty: true, AuthorEmpty: true}
+
+			// this only makes sense with MarshalWithURLs. Otherwise, the jsonapi spec would be
+			// violated, because you at least need a data, links, or meta field
+			i, err := MarshalWithURLs(post, CompleteServerInformation{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(i).To(Equal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":   "123",
+					"type": "posts",
+					"attributes": map[string]interface{}{
+						"title": "Test",
+					},
+					"relationships": map[string]map[string]interface{}{
+						"author": map[string]interface{}{
+							"links": map[string]string{
+								"self":    "http://my.domain/v1/posts/123/relationships/author",
+								"related": "http://my.domain/v1/posts/123/author",
+							},
+						},
+						"comments": map[string]interface{}{
+							"links": map[string]string{
+								"self":    "http://my.domain/v1/posts/123/relationships/comments",
+								"related": "http://my.domain/v1/posts/123/comments",
+							},
+						},
+					},
+				},
+			}))
+		})
+		It("skips data field for not loaded author relation", func() {
+			post := Post{ID: 123, Title: "Test", AuthorEmpty: true}
+
+			// this only makes sense with MarshalWithURLs. Otherwise, the jsonapi spec would be
+			// violated, because you at least need a data, links, or meta field
+			i, err := MarshalWithURLs(post, CompleteServerInformation{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(i).To(Equal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":   "123",
+					"type": "posts",
+					"attributes": map[string]interface{}{
+						"title": "Test",
+					},
+					"relationships": map[string]map[string]interface{}{
+						"author": map[string]interface{}{
+							"links": map[string]string{
+								"self":    "http://my.domain/v1/posts/123/relationships/author",
+								"related": "http://my.domain/v1/posts/123/author",
+							},
+						},
+						"comments": map[string]interface{}{
+							"data": []interface{}{},
+							"links": map[string]string{
+								"self":    "http://my.domain/v1/posts/123/relationships/comments",
+								"related": "http://my.domain/v1/posts/123/comments",
+							},
+						},
+					},
+				},
+			}))
+		})
+		It("skips data field for not loaded comments", func() {
+			post := Post{ID: 123, Title: "Test", CommentsEmpty: true}
+
+			// this only makes sense with MarshalWithURLs. Otherwise, the jsonapi spec would be
+			// violated, because you at least need a data, links, or meta field
+			i, err := MarshalWithURLs(post, CompleteServerInformation{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(i).To(Equal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":   "123",
+					"type": "posts",
+					"attributes": map[string]interface{}{
+						"title": "Test",
+					},
+					"relationships": map[string]map[string]interface{}{
+						"author": map[string]interface{}{
+							"data": nil,
+							"links": map[string]string{
+								"self":    "http://my.domain/v1/posts/123/relationships/author",
+								"related": "http://my.domain/v1/posts/123/author",
+							},
+						},
+						"comments": map[string]interface{}{
+							"links": map[string]string{
+								"self":    "http://my.domain/v1/posts/123/relationships/comments",
+								"related": "http://my.domain/v1/posts/123/comments",
+							},
+						},
+					},
+				},
+			}))
+		})
+	})
+
 	Context("when marshalling zero value types", func() {
 		theFloat := zero.NewFloat(2.3, true)
 		post := ZeroPost{ID: "1", Title: "test", Value: theFloat}


### PR DESCRIPTION
This is useful if a user only wants to include the `links` without `data`.
Sometimes loading relationships is a very expensive operation. If relations
are not needed anyway, it is enough to send the links. A client can then
access the relations at a later time via the provided links.

This resolves #141 