### PR TITLE
add return object to method not allowed error.

### DIFF
--- a/api.go
+++ b/api.go
@@ -17,6 +17,8 @@ import (
 	"github.com/manyminds/api2go/jsonapi"
 )
 
+const defaultContentTypHeader = "application/vnd.api+json"
+
 // The CRUD interface MUST be implemented in order to use the api2go api.
 type CRUD interface {
 	// FindOne returns an object by its ID
@@ -280,7 +282,7 @@ func (m JSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
 // Currently this means handling application/vnd.api+json content type bodies
 // using the standard encoding/json package.
 var DefaultContentMarshalers = map[string]ContentMarshaler{
-	"application/vnd.api+json": JSONContentMarshaler{},
+	defaultContentTypHeader: JSONContentMarshaler{},
 }
 
 //SetRedirectTrailingSlash enables 307 redirects on urls ending with /
@@ -965,7 +967,7 @@ func selectContentMarshaler(r *http.Request, marshalers map[string]ContentMarsha
 			contentTypes = append(contentTypes, ct)
 		}
 
-		contentType = httputil.NegotiateContentType(r, contentTypes, "application/vnd.api+json")
+		contentType = httputil.NegotiateContentType(r, contentTypes, defaultContentTypHeader)
 		marshaler = marshalers[contentType]
 	} else if contentTypes, found := r.Header["Content-Type"]; found {
 		contentType = contentTypes[0]
@@ -973,7 +975,7 @@ func selectContentMarshaler(r *http.Request, marshalers map[string]ContentMarsha
 	}
 
 	if marshaler == nil {
-		contentType = "application/vnd.api+json"
+		contentType = defaultContentTypHeader
 		marshaler = JSONContentMarshaler{}
 	}
 

--- a/api.go
+++ b/api.go
@@ -195,6 +195,15 @@ func (i information) GetPrefix() string {
 	return i.prefix
 }
 
+type notAllowedHandler struct {
+}
+
+func (n notAllowedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := NewHTTPError(nil, "Method Not Allowed", http.StatusMethodNotAllowed)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	w.Write([]byte(marshalHTTPError(err, JSONContentMarshaler{})))
+}
+
 // NewAPI returns an initialized API instance
 // `prefix` is added in front of all endpoints.
 func NewAPI(prefix string) *API {
@@ -206,8 +215,11 @@ func NewAPI(prefix string) *API {
 		prefixSlashes = "/"
 	}
 
+	router := httprouter.New()
+	router.MethodNotAllowed = notAllowedHandler{}
+
 	return &API{
-		router:     httprouter.New(),
+		router:     router,
 		prefix:     prefixSlashes,
 		info:       information{prefix: prefix},
 		marshalers: DefaultContentMarshalers,

--- a/api_test.go
+++ b/api_test.go
@@ -1395,5 +1395,17 @@ var _ = Describe("RestHandler", func() {
 				Expect(links).To(HaveLen(0))
 			})
 		})
+
+		Context("error codes", func() {
+			It("Should return the correct header on method not allowed", func() {
+				reqBody := strings.NewReader("")
+				req, err := http.NewRequest("PATCH", "/v1/posts", reqBody)
+				Expect(err).To(BeNil())
+				api.Handler().ServeHTTP(rec, req)
+				expected := `{"errors":[{"status":"405","title":"Method Not Allowed"}]}`
+				Expect(rec.Body.String()).To(MatchJSON(expected))
+				Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+			})
+		})
 	})
 })

--- a/api_test.go
+++ b/api_test.go
@@ -1404,6 +1404,7 @@ var _ = Describe("RestHandler", func() {
 				api.Handler().ServeHTTP(rec, req)
 				expected := `{"errors":[{"status":"405","title":"Method Not Allowed"}]}`
 				Expect(rec.Body.String()).To(MatchJSON(expected))
+				Expect(rec.Header().Get("Content-Type")).To(Equal(defaultContentTypHeader))
 				Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
 			})
 		})


### PR DESCRIPTION
Fixes #143 

This commit introduces our custom method not allowed handler
currently its private, since there is no need to replace it from
the outside.

TODO: 
- [x] ContentMarshaler must not be hardcoded.
- [x] Return correct json content type.
- [x] Assure that all errors will always return an error object.