### PR TITLE
Introduce public MarshalError for content type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The `ContentMarshaler` interface declares two functions
 type ContentMarshaler interface {
   Marshal(i interface{}) ([]byte, error)
   Unmarshal(data []byte, i interface{}) error
+  MarshalError(err error) string
 }
 ```
 

--- a/api.go
+++ b/api.go
@@ -843,10 +843,10 @@ func handleError(err error, w http.ResponseWriter, r *http.Request, marshalers m
 
 	log.Println(err)
 	if e, ok := err.(HTTPError); ok {
-		writeResult(w, []byte(marshalError(e, marshaler)), e.status, contentType)
+		writeResult(w, []byte(marshaler.MarshalError(err)), e.status, contentType)
 		return
 
 	}
 
-	writeResult(w, []byte(marshalError(err, marshaler)), http.StatusInternalServerError, contentType)
+	writeResult(w, []byte(marshaler.MarshalError(err)), http.StatusInternalServerError, contentType)
 }

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -23,6 +23,7 @@ type CRUD interface {
 type ContentMarshaler interface {
 	Marshal(i interface{}) ([]byte, error)
 	Unmarshal(data []byte, i interface{}) error
+	MarshalError(error) string
 }
 
 // The PaginatedFindAll interface can be optionally implemented to fetch a subset of all records.

--- a/api_test.go
+++ b/api_test.go
@@ -416,6 +416,11 @@ func (m prettyJSONContentMarshaler) Unmarshal(data []byte, i interface{}) error 
 	return json.Unmarshal(data, i)
 }
 
+func (m prettyJSONContentMarshaler) MarshalError(err error) string {
+	jsonmarshaler := JSONContentMarshaler{}
+	return jsonmarshaler.MarshalError(err)
+}
+
 var _ = Describe("RestHandler", func() {
 
 	var usePointerResources bool

--- a/error.go
+++ b/error.go
@@ -54,16 +54,17 @@ type ErrorSource struct {
 	Parameter string `json:"parameter,omitempty"`
 }
 
-//marshalError marshals all error types
-func marshalError(err error, marshaler ContentMarshaler) string {
+//MarshalError marshals errors recursively in json format.
+//it can make use of the jsonapi.HTTPError struct
+func (j JSONContentMarshaler) MarshalError(err error) string {
 	httpErr, ok := err.(HTTPError)
 	if ok {
-		return marshalHTTPError(httpErr, marshaler)
+		return marshalHTTPError(httpErr, j)
 	}
 
 	httpErr = NewHTTPError(err, err.Error(), 500)
 
-	return marshalHTTPError(httpErr, marshaler)
+	return marshalHTTPError(httpErr, j)
 }
 
 //marshalHTTPError marshals an internal httpError

--- a/error_test.go
+++ b/error_test.go
@@ -22,14 +22,16 @@ var _ = Describe("Errors test", func() {
 	Context("Marshalling", func() {
 		It("will be marshalled correctly with default error", func() {
 			httpErr := errors.New("Invalid use case done")
-			result := marshalError(httpErr, JSONContentMarshaler{})
+			m := JSONContentMarshaler{}
+			result := m.MarshalError(httpErr)
 			expected := `{"errors":[{"status":"500","title":"Invalid use case done"}]}`
 			Expect(result).To(Equal(expected))
 		})
 
 		It("will be marshalled correctly without child errors", func() {
+			m := JSONContentMarshaler{}
 			httpErr := NewHTTPError(errors.New("Bad Request"), "Bad Request", 400)
-			result := marshalError(httpErr, JSONContentMarshaler{})
+			result := m.MarshalError(httpErr)
 			expected := `{"errors":[{"status":"400","title":"Bad Request"}]}`
 			Expect(result).To(Equal(expected))
 		})
@@ -56,7 +58,8 @@ var _ = Describe("Errors test", func() {
 
 			httpErr.Errors = append(httpErr.Errors, errorOne)
 
-			result := marshalError(httpErr, JSONContentMarshaler{})
+			m := JSONContentMarshaler{}
+			result := m.MarshalError(httpErr)
 			expected := `{"errors":[{"id":"001","links":{"about":"http://bla/blub"},"status":"500","code":"001","title":"Title must not be empty","detail":"Never occures in real life","source":{"pointer":"#titleField"},"meta":{"creator":"api2go"}}]}`
 			Expect(result).To(Equal(expected))
 		})
@@ -77,7 +80,8 @@ var _ = Describe("Errors test", func() {
 
 			httpErr.Errors = append(httpErr.Errors, errorOne)
 
-			result := marshalError(httpErr, JSONContentMarshaler{})
+			m := JSONContentMarshaler{}
+			result := m.MarshalError(httpErr)
 			expected := `{"errors":[{"id":"001","status":"500","code":"001","title":"Title must not be empty","detail":"Never occures in real life","meta":{"creator":"api2go"}}]}`
 			Expect(result).To(Equal(expected))
 		})

--- a/examples/crud_example.go
+++ b/examples/crud_example.go
@@ -64,6 +64,11 @@ func (m PrettyJSONContentMarshaler) Unmarshal(data []byte, i interface{}) error 
 	return json.Unmarshal(data, i)
 }
 
+func (m PrettyJSONContentMarshaler) MarshalError(err error) string {
+	jsonmarshaler := api2go.JSONContentMarshaler{}
+	return jsonmarshaler.MarshalError(err)
+}
+
 func main() {
 	marshalers := map[string]api2go.ContentMarshaler{
 		"application/vnd.api+json": PrettyJSONContentMarshaler{},


### PR DESCRIPTION
fixes #117.

The MarshalError method is now public api of the ContentMarshaler interface. It only makes sense here since its necessary to implement different behaviour when using another encoding e.g. cbor.

This PR is a breaking change if someone has already implemented custom content marshalers. 