### PR TITLE
Add return code to Resource interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ go get github.com/manyminds/api2go/jsonapi
 ## TOC
 - [Examples](#examples)
 - [Interfaces to implement](#interfaces-to-implement)
+  - [Responder](#responder)
   - [EntityNamer](#entitynamer)
   - [MarshalIdentifier](#marshalidentifier)
   - [UnmarshalIdentifier](#unmarshalidentifier)
@@ -68,6 +69,19 @@ json ignore tag. Api2go will use the `GetID` method that you implemented for you
 
 In order to use different internal names for elements, you can specify a jsonapi tag. The api will marshal results now with the name in the tag.
 Create/Update/Delete works accordingly, but will fallback to the internal value as well if possible.
+
+### Responder
+```go
+type Responder interface {
+	Metadata() map[string]interface{}
+	Result() interface{}
+	StatusCode() int
+}
+```
+
+The Responder interface must be implemented if you are using our API. It
+contains everything that is needed for a response. You can see an example usage
+of it in our example project.
 
 ### EntityNamer
 ```go
@@ -306,19 +320,19 @@ First, write an implementation of `api2go.CRUD`. You have to implement at least 
 ```go
 type fixtureSource struct {}
 
-func (s *fixtureSource) FindOne(ID string, r api2go.Request) (interface{}, error) {
+func (s *fixtureSource) FindOne(ID string, r api2go.Request) (Responder, error) {
   // Return a single post by ID as Post
 }
 
-func (s *fixtureSource) Create(obj interface{}, r api2go.Request) (ID string, status int, err error) {
+func (s *fixtureSource) Create(obj interface{}, r api2go.Request) (Responder, err error) {
   // Save the new Post in `obj` and return its ID.
 }
 
-func (s *fixtureSource) Delete(id string, r api2go.Request) (status int, err error) {
+func (s *fixtureSource) Delete(id string, r api2go.Request) (Responder, err error) {
   // Delete a post
 }
 
-func (s *fixtureSource) Update(obj interface{}, r api2go.Request) (status int, err error) {
+func (s *fixtureSource) Update(obj interface{}, r api2go.Request) (Responder, err error) {
   // Apply the new values in the Post in `obj`
 }
 ```
@@ -329,11 +343,11 @@ interfaces:
 ```go
 type FindAll interface {
 	// FindAll returns all objects
-	FindAll(req Request) (interface{}, error)
+	FindAll(req Request) (Responder, error)
 }
 
 type PaginatedFindAll interface {
-	PaginatedFindAll(req Request) (obj interface{}, totalCount uint, err error)
+	PaginatedFindAll(req Request) (totalCount uint, response Responder, err error)
 }
 ```
 
@@ -523,7 +537,7 @@ query Paramter and only return comments that belong to it. In this example, retu
 ## Tests
 
 ```sh
-go test
-ginkgo                # Alternative
-ginkgo watch -notify  # Watch for changes
+go test ./...
+ginkgo -r                # Alternative
+ginkgo watch -r -notify  # Watch for changes
 ```

--- a/README.md
+++ b/README.md
@@ -310,15 +310,15 @@ func (s *fixtureSource) FindOne(ID string, r api2go.Request) (interface{}, error
   // Return a single post by ID as Post
 }
 
-func (s *fixtureSource) Create(obj interface{}, r api2go.Request) (string, error) {
+func (s *fixtureSource) Create(obj interface{}, r api2go.Request) (ID string, status int, err error) {
   // Save the new Post in `obj` and return its ID.
 }
 
-func (s *fixtureSource) Delete(id string, r api2go.Request) error {
+func (s *fixtureSource) Delete(id string, r api2go.Request) (status int, err error) {
   // Delete a post
 }
 
-func (s *fixtureSource) Update(obj interface{}, r api2go.Request) error {
+func (s *fixtureSource) Update(obj interface{}, r api2go.Request) (status int, err error) {
   // Apply the new values in the Post in `obj`
 }
 ```

--- a/api.go
+++ b/api.go
@@ -831,8 +831,11 @@ func (res *resource) handleDelete(w http.ResponseWriter, r *http.Request, ps htt
 
 	switch response.StatusCode() {
 	case http.StatusOK:
-		// TODO: implement this.. we need meta data as return value
-		return fmt.Errorf("status 200 OK is currently not implemented for Delete methods")
+		data := map[string]interface{}{
+			"meta": response.Metadata(),
+		}
+
+		return marshalResponse(data, w, http.StatusOK, r, res.marshalers)
 	case http.StatusAccepted:
 		w.WriteHeader(http.StatusAccepted)
 		return nil

--- a/api.go
+++ b/api.go
@@ -431,6 +431,10 @@ func (res *resource) handleReadRelation(w http.ResponseWriter, r *http.Request, 
 		"related": related,
 	}
 	result["data"] = relationData
+	meta := obj.Metadata()
+	if len(meta) > 0 {
+		result["meta"] = meta
+	}
 
 	return marshalResponse(result, w, http.StatusOK, r, res.marshalers)
 }
@@ -852,6 +856,11 @@ func respondWith(obj Responder, info information, status int, w http.ResponseWri
 		return err
 	}
 
+	meta := obj.Metadata()
+	if len(meta) > 0 {
+		data["meta"] = meta
+	}
+
 	return marshalResponse(data, w, status, r, marshalers)
 }
 
@@ -862,6 +871,11 @@ func respondWithPagination(obj Responder, info information, status int, links ma
 	}
 
 	data["links"] = links
+	meta := obj.Metadata()
+	if len(meta) > 0 {
+		data["meta"] = meta
+	}
+
 	return marshalResponse(data, w, status, r, marshalers)
 }
 

--- a/api.go
+++ b/api.go
@@ -448,7 +448,7 @@ func (res *resource) handleLinked(api *API, w http.ResponseWriter, r *http.Reque
 			request.QueryParams[res.name+"ID"] = []string{id}
 			request.QueryParams[res.name+"Name"] = []string{linked.Name}
 
-			// check for paginatioy, otherwise normal FindAll
+			// check for pagination, otherwise normal FindAll
 			pagination := newPaginationQueryParams(r)
 			if pagination.isValid() {
 				source, ok := resource.source.(PaginatedFindAll)

--- a/api_entity_name_test.go
+++ b/api_entity_name_test.go
@@ -46,16 +46,16 @@ func (s BaguetteResource) FindAll(req Request) (interface{}, error) {
 	}, nil
 }
 
-func (s BaguetteResource) Create(obj interface{}, req Request) (string, error) {
-	return "newID", nil
+func (s BaguetteResource) Create(obj interface{}, req Request) (string, int, error) {
+	return "newID", http.StatusCreated, nil
 }
 
-func (s BaguetteResource) Delete(ID string, req Request) error {
-	return nil
+func (s BaguetteResource) Delete(ID string, req Request) (int, error) {
+	return http.StatusNoContent, nil
 }
 
-func (s BaguetteResource) Update(obj interface{}, req Request) error {
-	return nil
+func (s BaguetteResource) Update(obj interface{}, req Request) (int, error) {
+	return http.StatusNoContent, nil
 }
 
 var _ = Describe("Test route renaming with EntityNamer interface", func() {

--- a/api_entity_name_test.go
+++ b/api_entity_name_test.go
@@ -29,12 +29,12 @@ func (s BaguetteTaste) GetName() string {
 
 type BaguetteResource struct{}
 
-func (s BaguetteResource) FindOne(ID string, req Request) (interface{}, error) {
-	return BaguetteTaste{ID: "blubb", Taste: "Very Bad"}, nil
+func (s BaguetteResource) FindOne(ID string, req Request) (Responder, error) {
+	return &Response{Res: BaguetteTaste{ID: "blubb", Taste: "Very Bad"}}, nil
 }
 
-func (s BaguetteResource) FindAll(req Request) (interface{}, error) {
-	return []BaguetteTaste{
+func (s BaguetteResource) FindAll(req Request) (Responder, error) {
+	return &Response{Res: []BaguetteTaste{
 		{
 			ID:    "1",
 			Taste: "Very Good",
@@ -43,19 +43,30 @@ func (s BaguetteResource) FindAll(req Request) (interface{}, error) {
 			ID:    "2",
 			Taste: "Very Bad",
 		},
+	}}, nil
+}
+
+func (s BaguetteResource) Create(obj interface{}, req Request) (Responder, error) {
+	e := obj.(BaguetteTaste)
+	e.ID = "newID"
+	return &Response{
+		Res:  e,
+		Code: http.StatusCreated,
 	}, nil
 }
 
-func (s BaguetteResource) Create(obj interface{}, req Request) (string, int, error) {
-	return "newID", http.StatusCreated, nil
+func (s BaguetteResource) Delete(ID string, req Request) (Responder, error) {
+	return &Response{
+		Res:  BaguetteTaste{ID: ID},
+		Code: http.StatusNoContent,
+	}, nil
 }
 
-func (s BaguetteResource) Delete(ID string, req Request) (int, error) {
-	return http.StatusNoContent, nil
-}
-
-func (s BaguetteResource) Update(obj interface{}, req Request) (int, error) {
-	return http.StatusNoContent, nil
+func (s BaguetteResource) Update(obj interface{}, req Request) (Responder, error) {
+	return &Response{
+		Res:  obj,
+		Code: http.StatusNoContent,
+	}, nil
 }
 
 var _ = Describe("Test route renaming with EntityNamer interface", func() {
@@ -115,12 +126,12 @@ var _ = Describe("Test route renaming with EntityNamer interface", func() {
 		{
 			"data": {
 				"attributes": {
-					"taste":"Very Bad"
+					"taste": "smells awful"
 				},
-				"id":"blubb",
-				"type":"baguette-tastes"
-				}
+				"id": "newID",
+				"type": "baguette-tastes"
 			}
+		}
 		`))
 		Expect(rec.Code).To(Equal(http.StatusCreated))
 	})

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -6,13 +6,26 @@ type CRUD interface {
 	FindOne(ID string, req Request) (interface{}, error)
 
 	// Create a new object and return its ID
-	Create(obj interface{}, req Request) (string, error)
+	// status is one of these 200 success codes
+	// - 201 Created: Resource was created and needs to be returned
+	// - 202 Accepted: Processing is delayed, return nothing
+	// - 204 No Content: Resource created with a client generated ID, and no fields were modified by
+	//   the server
+	Create(obj interface{}, req Request) (id string, status int, err error)
 
 	// Delete an object
-	Delete(id string, req Request) error
+	// status is one of these 200 success codes
+	// - 200 OK: Update successful, however some field(s) were changed, returns updates source
+	// - 202 Accepted: Processing is delayed, return nothing
+	// - 204 No Content: Update was successful, no fields were changed by the server, return nothing
+	Delete(id string, req Request) (status int, err error)
 
 	// Update an object
-	Update(obj interface{}, req Request) error
+	// status is one of these 200 success codes
+	// - 200 OK: Deletion was a success, returns meta information, currently not implemented! Do not use this
+	// - 202 Accepted: Processing is delayed, return nothing
+	// - 204 No Content: Deletion was successful, return nothing
+	Update(obj interface{}, req Request) (status int, err error)
 }
 
 // ContentMarshaler controls how requests from clients are unmarshaled

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -54,7 +54,7 @@ type FindAll interface {
 	FindAll(req Request) (Responder, error)
 }
 
-// The Responder interface is used by all Resource Methods as a container for the Response
+// The Responder interface is used by all Resource Methods as a container for the Response.
 // Metadata is additional Metadata. You can put anything you like into it, see jsonapi spec.
 // Result returns the actual payload. For FindOne, put only one entry in it.
 // StatusCode sets the http status code.

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -59,7 +59,7 @@ type FindAll interface {
 // Result returns the actual payload. For FindOne, put only one entry in it.
 // StatusCode sets the http status code.
 type Responder interface {
-	MetaData() map[string]interface{}
+	Metadata() map[string]interface{}
 	Result() interface{}
 	StatusCode() int
 }

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -3,29 +3,29 @@ package api2go
 // The CRUD interface MUST be implemented in order to use the api2go api.
 type CRUD interface {
 	// FindOne returns an object by its ID
-	FindOne(ID string, req Request) (interface{}, error)
+	FindOne(ID string, req Request) (Responder, error)
 
-	// Create a new object and return its ID
-	// status is one of these 200 success codes
+	// Create a new object. Newly created object/struct must be in Responder.
+	// Possible status codes are:
 	// - 201 Created: Resource was created and needs to be returned
 	// - 202 Accepted: Processing is delayed, return nothing
 	// - 204 No Content: Resource created with a client generated ID, and no fields were modified by
 	//   the server
-	Create(obj interface{}, req Request) (id string, status int, err error)
+	Create(obj interface{}, req Request) (Responder, error)
 
 	// Delete an object
-	// status is one of these 200 success codes
+	// Possible status codes are:
 	// - 200 OK: Update successful, however some field(s) were changed, returns updates source
 	// - 202 Accepted: Processing is delayed, return nothing
 	// - 204 No Content: Update was successful, no fields were changed by the server, return nothing
-	Delete(id string, req Request) (status int, err error)
+	Delete(id string, req Request) (Responder, error)
 
 	// Update an object
-	// status is one of these 200 success codes
+	// Possible status codes are:
 	// - 200 OK: Deletion was a success, returns meta information, currently not implemented! Do not use this
 	// - 202 Accepted: Processing is delayed, return nothing
 	// - 204 No Content: Deletion was successful, return nothing
-	Update(obj interface{}, req Request) (status int, err error)
+	Update(obj interface{}, req Request) (Responder, error)
 }
 
 // ContentMarshaler controls how requests from clients are unmarshaled
@@ -45,11 +45,21 @@ type ContentMarshaler interface {
 // page[number] AND page[size]
 // OR page[offset] AND page[limit]
 type PaginatedFindAll interface {
-	PaginatedFindAll(req Request) (obj interface{}, totalCount uint, err error)
+	PaginatedFindAll(req Request) (totalCount uint, response Responder, err error)
 }
 
 // The FindAll interface can be optionally implemented to fetch all records at once.
 type FindAll interface {
 	// FindAll returns all objects
-	FindAll(req Request) (interface{}, error)
+	FindAll(req Request) (Responder, error)
+}
+
+// The Responder interface is used by all Resource Methods as a container for the Response
+// Metadata is additional Metadata. You can put anything you like into it, see jsonapi spec.
+// Result returns the actual payload. For FindOne, put only one entry in it.
+// StatusCode sets the http status code.
+type Responder interface {
+	MetaData() map[string]interface{}
+	Result() interface{}
+	StatusCode() int
 }

--- a/api_interfaces_test.go
+++ b/api_interfaces_test.go
@@ -1,15 +1,19 @@
 package api2go
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 
+	"github.com/manyminds/api2go/jsonapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 type SomeData struct {
-	ID   string
+	ID   string `json:"-"`
 	Data string
 }
 
@@ -28,16 +32,52 @@ func (s SomeResource) FindOne(ID string, req Request) (interface{}, error) {
 	return SomeData{ID: "12345", Data: "A Brezzn"}, nil
 }
 
-func (s SomeResource) Create(obj interface{}, req Request) (string, error) {
-	return "newID", nil
+func (s SomeResource) Create(obj interface{}, req Request) (string, int, error) {
+	incoming := obj.(SomeData)
+	switch incoming.ID {
+	case "":
+		return "newID", http.StatusCreated, nil
+	case "accept":
+		return "someID", http.StatusAccepted, nil
+	case "forbidden":
+		return "", 0, NewHTTPError(nil, "Forbidden", http.StatusForbidden)
+	case "conflict":
+		return "", 0, NewHTTPError(nil, "Conflict", http.StatusConflict)
+	case "invalid":
+		return "", http.StatusTeapot, nil
+	default:
+		return incoming.ID, http.StatusNoContent, nil
+	}
 }
 
-func (s SomeResource) Delete(ID string, req Request) error {
-	return nil
+func (s SomeResource) Delete(ID string, req Request) (int, error) {
+	switch ID {
+	case "200":
+		// TODO: needs to be implemented, function signature is likely to be changed to return meta data
+		return http.StatusOK, nil
+	case "202":
+		return http.StatusAccepted, nil
+	default:
+		return http.StatusNoContent, nil
+	}
 }
 
-func (s SomeResource) Update(obj interface{}, req Request) error {
-	return nil
+func (s SomeResource) Update(obj interface{}, req Request) (int, error) {
+	incoming := obj.(SomeData)
+	switch incoming.Data {
+	case "override me":
+		return http.StatusOK, nil
+	case "delayed":
+		return http.StatusAccepted, nil
+	case "new value":
+		return http.StatusNoContent, nil
+	case "fail":
+		return 0, NewHTTPError(nil, "Fail", http.StatusForbidden)
+	case "invalid":
+		return http.StatusTeapot, nil
+	default:
+		return http.StatusNoContent, nil
+	}
 }
 
 var _ = Describe("Test interface api type casting", func() {
@@ -63,5 +103,160 @@ var _ = Describe("Test interface api type casting", func() {
 		Expect(err).ToNot(HaveOccurred())
 		api.Handler().ServeHTTP(rec, req)
 		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+})
+
+var _ = Describe("Test return code behavior", func() {
+	var (
+		api                *API
+		rec                *httptest.ResponseRecorder
+		payload, payloadID SomeData
+	)
+
+	BeforeEach(func() {
+		api = NewAPI("v1")
+		api.AddResource(SomeData{}, SomeResource{})
+		rec = httptest.NewRecorder()
+		payloadID = SomeData{ID: "12345", Data: "A Brezzn"}
+		payload = SomeData{Data: "A Brezzn"}
+	})
+
+	Context("Create", func() {
+		post := func(payload SomeData) {
+			m, err := jsonapi.MarshalToJSON(payload)
+			Expect(err).ToNot(HaveOccurred())
+			req, err := http.NewRequest("POST", "/v1/someDatas", strings.NewReader(string(m)))
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+		}
+
+		It("returns object with 201 created", func() {
+			post(payload)
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+			var actual SomeData
+			err := jsonapi.UnmarshalFromJSON(rec.Body.Bytes(), &actual)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(payloadID).To(Equal(actual))
+		})
+
+		It("return no content 204 with client side generated id", func() {
+			post(payloadID)
+			Expect(rec.Code).To(Equal(http.StatusNoContent))
+			Expect(rec.Body.String()).To(BeEmpty())
+		})
+
+		It("return accepted and no content", func() {
+			post(SomeData{ID: "accept", Data: "nothing"})
+			Expect(rec.Code).To(Equal(http.StatusAccepted))
+			Expect(rec.Body.String()).To(BeEmpty())
+		})
+
+		It("does not accept invalid return codes", func() {
+			post(SomeData{ID: "invalid"})
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+			var err HTTPError
+			json.Unmarshal(rec.Body.Bytes(), &err)
+			Expect(err.Errors[0]).To(Equal(Error{
+				Title:  "invalid status code 418 from resource someDatas for method Create",
+				Status: strconv.Itoa(http.StatusInternalServerError)}))
+		})
+
+		It("handles forbidden 403 error", func() {
+			post(SomeData{ID: "forbidden", Data: "i am so forbidden"})
+			Expect(rec.Code).To(Equal(http.StatusForbidden))
+			var err HTTPError
+			json.Unmarshal(rec.Body.Bytes(), &err)
+			Expect(err.Errors[0]).To(Equal(Error{Title: "Forbidden", Status: strconv.Itoa(http.StatusForbidden)}))
+		})
+
+		It("handles 409 conflict error", func() {
+			post(SomeData{ID: "conflict", Data: "no force push here"})
+			Expect(rec.Code).To(Equal(http.StatusConflict))
+			var err HTTPError
+			json.Unmarshal(rec.Body.Bytes(), &err)
+			Expect(err.Errors[0]).To(Equal(Error{Title: "Conflict", Status: strconv.Itoa(http.StatusConflict)}))
+		})
+	})
+
+	Context("Update", func() {
+		patch := func(payload SomeData) {
+			m, err := jsonapi.MarshalToJSON(payload)
+			Expect(err).ToNot(HaveOccurred())
+			req, err := http.NewRequest("PATCH", "/v1/someDatas/12345", strings.NewReader(string(m)))
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+		}
+
+		It("returns 200 ok if the server modified a field", func() {
+			patch(SomeData{ID: "12345", Data: "override me"})
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			var actual SomeData
+			err := jsonapi.UnmarshalFromJSON(rec.Body.Bytes(), &actual)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(payloadID).To(Equal(actual))
+		})
+
+		It("returns 202 Accepted if update is delayed", func() {
+			patch(SomeData{ID: "12345", Data: "delayed"})
+			Expect(rec.Code).To(Equal(http.StatusAccepted))
+			Expect(rec.Body.String()).To(BeEmpty())
+		})
+
+		It("returns 204 No Content if update was accepted", func() {
+			patch(SomeData{ID: "12345", Data: "new value"})
+			Expect(rec.Code).To(Equal(http.StatusNoContent))
+			Expect(rec.Body.String()).To(BeEmpty())
+		})
+
+		It("does not accept invalid return codes", func() {
+			patch(SomeData{ID: "12345", Data: "invalid"})
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+			var err HTTPError
+			json.Unmarshal(rec.Body.Bytes(), &err)
+			Expect(err.Errors[0]).To(Equal(Error{
+				Title:  "invalid status code 418 from resource someDatas for method Update",
+				Status: strconv.Itoa(http.StatusInternalServerError)}))
+		})
+
+		// We do not check everything again like in Create, because it's always the same handleError
+		// method that get's called.
+		It("handles error cases", func() {
+			patch(SomeData{ID: "12345", Data: "fail"})
+			Expect(rec.Code).To(Equal(http.StatusForbidden), "we do not allow failes here!")
+			var err HTTPError
+			json.Unmarshal(rec.Body.Bytes(), &err)
+			Expect(err.Errors[0]).To(Equal(Error{Title: "Fail", Status: strconv.Itoa(http.StatusForbidden)}))
+		})
+
+	})
+
+	Context("Delete", func() {
+		delete := func(ID string) {
+			req, err := http.NewRequest("DELETE", "/v1/someDatas/"+ID, nil)
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+		}
+
+		It("returns 200 ok if there is some meta data", func() {
+			delete("200")
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+			var err HTTPError
+			json.Unmarshal(rec.Body.Bytes(), &err)
+			Expect(err.Errors[0]).To(Equal(Error{
+				Title:  "status 200 OK is currently not implemented for Delete methods",
+				Status: strconv.Itoa(http.StatusInternalServerError)}))
+		})
+
+		It("returns 202 accepted if deletion is delayed", func() {
+			delete("202")
+			Expect(rec.Code).To(Equal(http.StatusAccepted))
+			Expect(rec.Body.String()).To(BeEmpty())
+		})
+
+		It("return 204 No Content if deletion just worked", func() {
+			delete("204")
+			Expect(rec.Code).To(Equal(http.StatusNoContent))
+			Expect(rec.Body.String()).To(BeEmpty())
+		})
 	})
 })

--- a/api_interfaces_test.go
+++ b/api_interfaces_test.go
@@ -28,55 +28,55 @@ func (s *SomeData) SetID(ID string) error {
 
 type SomeResource struct{}
 
-func (s SomeResource) FindOne(ID string, req Request) (interface{}, error) {
-	return SomeData{ID: "12345", Data: "A Brezzn"}, nil
+func (s SomeResource) FindOne(ID string, req Request) (Responder, error) {
+	return &Response{Res: SomeData{ID: "12345", Data: "A Brezzn"}}, nil
 }
 
-func (s SomeResource) Create(obj interface{}, req Request) (string, int, error) {
+func (s SomeResource) Create(obj interface{}, req Request) (Responder, error) {
 	incoming := obj.(SomeData)
 	switch incoming.ID {
 	case "":
-		return "newID", http.StatusCreated, nil
+		return &Response{Res: SomeData{ID: "12345", Data: "A Brezzn"}, Code: http.StatusCreated}, nil
 	case "accept":
-		return "someID", http.StatusAccepted, nil
+		return &Response{Res: SomeData{ID: "someID"}, Code: http.StatusAccepted}, nil
 	case "forbidden":
-		return "", 0, NewHTTPError(nil, "Forbidden", http.StatusForbidden)
+		return &Response{}, NewHTTPError(nil, "Forbidden", http.StatusForbidden)
 	case "conflict":
-		return "", 0, NewHTTPError(nil, "Conflict", http.StatusConflict)
+		return &Response{}, NewHTTPError(nil, "Conflict", http.StatusConflict)
 	case "invalid":
-		return "", http.StatusTeapot, nil
+		return &Response{Res: SomeData{}, Code: http.StatusTeapot}, nil
 	default:
-		return incoming.ID, http.StatusNoContent, nil
+		return &Response{Res: SomeData{ID: incoming.ID}, Code: http.StatusNoContent}, nil
 	}
 }
 
-func (s SomeResource) Delete(ID string, req Request) (int, error) {
+func (s SomeResource) Delete(ID string, req Request) (Responder, error) {
 	switch ID {
 	case "200":
 		// TODO: needs to be implemented, function signature is likely to be changed to return meta data
-		return http.StatusOK, nil
+		return &Response{Code: http.StatusOK, Meta: map[string]interface{}{"some": "cool stuff"}}, nil
 	case "202":
-		return http.StatusAccepted, nil
+		return &Response{Code: http.StatusAccepted}, nil
 	default:
-		return http.StatusNoContent, nil
+		return &Response{Code: http.StatusNoContent}, nil
 	}
 }
 
-func (s SomeResource) Update(obj interface{}, req Request) (int, error) {
+func (s SomeResource) Update(obj interface{}, req Request) (Responder, error) {
 	incoming := obj.(SomeData)
 	switch incoming.Data {
 	case "override me":
-		return http.StatusOK, nil
+		return &Response{Code: http.StatusOK}, nil
 	case "delayed":
-		return http.StatusAccepted, nil
+		return &Response{Code: http.StatusAccepted}, nil
 	case "new value":
-		return http.StatusNoContent, nil
+		return &Response{Code: http.StatusNoContent}, nil
 	case "fail":
-		return 0, NewHTTPError(nil, "Fail", http.StatusForbidden)
+		return &Response{}, NewHTTPError(nil, "Fail", http.StatusForbidden)
 	case "invalid":
-		return http.StatusTeapot, nil
+		return &Response{Code: http.StatusTeapot}, nil
 	default:
-		return http.StatusNoContent, nil
+		return &Response{Code: http.StatusNoContent}, nil
 	}
 }
 

--- a/api_interfaces_test.go
+++ b/api_interfaces_test.go
@@ -53,7 +53,6 @@ func (s SomeResource) Create(obj interface{}, req Request) (Responder, error) {
 func (s SomeResource) Delete(ID string, req Request) (Responder, error) {
 	switch ID {
 	case "200":
-		// TODO: needs to be implemented, function signature is likely to be changed to return meta data
 		return &Response{Code: http.StatusOK, Meta: map[string]interface{}{"some": "cool stuff"}}, nil
 	case "202":
 		return &Response{Code: http.StatusAccepted}, nil
@@ -239,12 +238,14 @@ var _ = Describe("Test return code behavior", func() {
 
 		It("returns 200 ok if there is some meta data", func() {
 			delete("200")
-			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
-			var err HTTPError
-			json.Unmarshal(rec.Body.Bytes(), &err)
-			Expect(err.Errors[0]).To(Equal(Error{
-				Title:  "status 200 OK is currently not implemented for Delete methods",
-				Status: strconv.Itoa(http.StatusInternalServerError)}))
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			var response map[string]interface{}
+			json.Unmarshal(rec.Body.Bytes(), &response)
+			Expect(response).To(Equal(map[string]interface{}{
+				"meta": map[string]interface{}{
+					"some": "cool stuff",
+				},
+			}))
 		})
 
 		It("returns 202 accepted if deletion is delayed", func() {

--- a/api_test.go
+++ b/api_test.go
@@ -28,15 +28,15 @@ type Response struct {
 	Code int
 }
 
-func (r *Response) MetaData() map[string]interface{} {
+func (r Response) Metadata() map[string]interface{} {
 	return r.Meta
 }
 
-func (r *Response) Result() interface{} {
+func (r Response) Result() interface{} {
 	return r.Res
 }
 
-func (r *Response) StatusCode() int {
+func (r Response) StatusCode() int {
 	return r.Code
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -276,7 +276,7 @@ func (s *fixtureSource) FindOne(id string, req Request) (interface{}, error) {
 	return nil, NewHTTPError(nil, "post not found", http.StatusNotFound)
 }
 
-func (s *fixtureSource) Create(obj interface{}, req Request) (string, error) {
+func (s *fixtureSource) Create(obj interface{}, req Request) (string, int, error) {
 	var p *Post
 	if s.pointers {
 		p = obj.(*Post)
@@ -288,7 +288,7 @@ func (s *fixtureSource) Create(obj interface{}, req Request) (string, error) {
 	if p.Title == "" {
 		err := NewHTTPError(errors.New("Bad request."), "Bad Request", http.StatusBadRequest)
 		err.Errors = append(err.Errors, Error{ID: "SomeErrorID", Source: &ErrorSource{Pointer: "Title"}})
-		return "", err
+		return "", 0, err
 	}
 
 	maxID := 0
@@ -301,15 +301,15 @@ func (s *fixtureSource) Create(obj interface{}, req Request) (string, error) {
 	newID := strconv.Itoa(maxID + 1)
 	p.ID = newID
 	s.posts[newID] = p
-	return newID, nil
+	return newID, http.StatusCreated, nil
 }
 
-func (s *fixtureSource) Delete(id string, req Request) error {
+func (s *fixtureSource) Delete(id string, req Request) (int, error) {
 	delete(s.posts, id)
-	return nil
+	return http.StatusNoContent, nil
 }
 
-func (s *fixtureSource) Update(obj interface{}, req Request) error {
+func (s *fixtureSource) Update(obj interface{}, req Request) (int, error) {
 	var p *Post
 	if s.pointers {
 		p = obj.(*Post)
@@ -321,9 +321,9 @@ func (s *fixtureSource) Update(obj interface{}, req Request) error {
 		oldP.Title = p.Title
 		oldP.Author = p.Author
 		oldP.Comments = p.Comments
-		return nil
+		return http.StatusNoContent, nil
 	}
-	return NewHTTPError(nil, "post not found", http.StatusNotFound)
+	return 0, NewHTTPError(nil, "post not found", http.StatusNotFound)
 }
 
 type userSource struct {
@@ -355,16 +355,16 @@ func (s *userSource) FindOne(id string, req Request) (interface{}, error) {
 	return nil, nil
 }
 
-func (s *userSource) Create(obj interface{}, req Request) (string, error) {
-	return "", nil
+func (s *userSource) Create(obj interface{}, req Request) (string, int, error) {
+	return "", http.StatusCreated, nil
 }
 
-func (s *userSource) Delete(id string, req Request) error {
-	return nil
+func (s *userSource) Delete(id string, req Request) (int, error) {
+	return http.StatusNoContent, nil
 }
 
-func (s *userSource) Update(obj interface{}, req Request) error {
-	return NewHTTPError(nil, "user not found", http.StatusNotFound)
+func (s *userSource) Update(obj interface{}, req Request) (int, error) {
+	return 0, NewHTTPError(nil, "user not found", http.StatusNotFound)
 }
 
 type commentSource struct {
@@ -399,16 +399,16 @@ func (s *commentSource) FindOne(id string, req Request) (interface{}, error) {
 	return nil, nil
 }
 
-func (s *commentSource) Create(obj interface{}, req Request) (string, error) {
-	return "", nil
+func (s *commentSource) Create(obj interface{}, req Request) (string, int, error) {
+	return "", http.StatusCreated, nil
 }
 
-func (s *commentSource) Delete(id string, req Request) error {
-	return nil
+func (s *commentSource) Delete(id string, req Request) (int, error) {
+	return http.StatusNoContent, nil
 }
 
-func (s *commentSource) Update(obj interface{}, req Request) error {
-	return NewHTTPError(nil, "comment not found", http.StatusNotFound)
+func (s *commentSource) Update(obj interface{}, req Request) (int, error) {
+	return 0, NewHTTPError(nil, "comment not found", http.StatusNotFound)
 }
 
 type prettyJSONContentMarshaler struct {

--- a/examples/crud_example_test.go
+++ b/examples/crud_example_test.go
@@ -44,6 +44,11 @@ var _ = Describe("CrudExample", func() {
 		Expect(rec.Code).To(Equal(http.StatusCreated))
 		Expect(rec.Body.String()).To(MatchJSON(`
 		{
+			"meta": {
+				"author": "The api2go examples crew",
+				"license": "wtfpl",
+				"license-url": "http://www.wtfpl.net"
+			},
 			"data": {
 				"id": "1",
 				"type": "users",
@@ -87,6 +92,11 @@ var _ = Describe("CrudExample", func() {
 		Expect(rec.Code).To(Equal(http.StatusCreated))
 		Expect(rec.Body.String()).To(MatchJSON(`
 		{
+			"meta": {
+				"author": "The api2go examples crew",
+				"license": "wtfpl",
+				"license-url": "http://www.wtfpl.net"
+			},
 			"data": {
 				"id": "1",
 				"type": "chocolates",
@@ -127,6 +137,11 @@ var _ = Describe("CrudExample", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rec.Body.String()).To(MatchJSON(`
 		{
+			"meta": {
+				"author": "The api2go examples crew",
+				"license": "wtfpl",
+				"license-url": "http://www.wtfpl.net"
+			},
 			"data": {
 				"attributes": {
 					"id": "1",
@@ -197,6 +212,11 @@ var _ = Describe("CrudExample", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rec.Body.String()).To(MatchJSON(`
 		{
+			"meta": {
+				"author": "The api2go examples crew",
+				"license": "wtfpl",
+				"license-url": "http://www.wtfpl.net"
+			},
 			"data": {
 				"attributes": {
 					"id": "1",
@@ -245,6 +265,11 @@ var _ = Describe("CrudExample", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rec.Body.String()).To(MatchJSON(`
 		{
+			"meta": {
+				"author": "The api2go examples crew",
+				"license": "wtfpl",
+				"license-url": "http://www.wtfpl.net"
+			},
 			"data": {
 				"attributes": {
 					"id": "1",
@@ -305,6 +330,11 @@ var _ = Describe("CrudExample", func() {
 			Expect(rec.Code).To(Equal(http.StatusCreated))
 			Expect(rec.Body.String()).To(MatchJSON(`
 			{
+				"meta": {
+					"author": "The api2go examples crew",
+					"license": "wtfpl",
+					"license-url": "http://www.wtfpl.net"
+				},
 				"data": {
 					"id": "2",
 					"type": "chocolates",
@@ -326,6 +356,11 @@ var _ = Describe("CrudExample", func() {
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			Expect(rec.Body.String()).To(MatchJSON(`
 			{
+				"meta": {
+					"author": "The api2go examples crew",
+					"license": "wtfpl",
+					"license-url": "http://www.wtfpl.net"
+				},
 				"data": [
 					{
 						"attributes": {
@@ -355,6 +390,11 @@ var _ = Describe("CrudExample", func() {
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			Expect(rec.Body.String()).To(MatchJSON(`
 			{
+				"meta": {
+					"author": "The api2go examples crew",
+					"license": "wtfpl",
+					"license-url": "http://www.wtfpl.net"
+				},
 				"data": {
 					"attributes": {
 						"id": "1",
@@ -398,6 +438,11 @@ var _ = Describe("CrudExample", func() {
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			Expect(rec.Body.String()).To(MatchJSON(`
 			{
+				"meta": {
+					"author": "The api2go examples crew",
+					"license": "wtfpl",
+					"license-url": "http://www.wtfpl.net"
+				},
 				"data": [
 					{
 						"id": "1",

--- a/examples/resource/resource_chocolate.go
+++ b/examples/resource/resource_chocolate.go
@@ -48,26 +48,29 @@ func (c ChocolateResource) FindOne(ID string, r api2go.Request) (interface{}, er
 }
 
 // Create a new choc
-func (c ChocolateResource) Create(obj interface{}, r api2go.Request) (string, error) {
+func (c ChocolateResource) Create(obj interface{}, r api2go.Request) (string, int, error) {
 	choc, ok := obj.(model.Chocolate)
 	if !ok {
-		return "", api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return "", 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
-	return c.ChocStorage.Insert(choc), nil
+	id := c.ChocStorage.Insert(choc)
+	return id, http.StatusCreated, nil
 }
 
 // Delete a choc :(
-func (c ChocolateResource) Delete(id string, r api2go.Request) error {
-	return c.ChocStorage.Delete(id)
+func (c ChocolateResource) Delete(id string, r api2go.Request) (int, error) {
+	err := c.ChocStorage.Delete(id)
+	return http.StatusNoContent, err
 }
 
 // Update a choc
-func (c ChocolateResource) Update(obj interface{}, r api2go.Request) error {
+func (c ChocolateResource) Update(obj interface{}, r api2go.Request) (int, error) {
 	choc, ok := obj.(model.Chocolate)
 	if !ok {
-		return api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
-	return c.ChocStorage.Update(choc)
+	err := c.ChocStorage.Update(choc)
+	return http.StatusNoContent, err
 }

--- a/examples/resource/resource_chocolate.go
+++ b/examples/resource/resource_chocolate.go
@@ -16,7 +16,7 @@ type ChocolateResource struct {
 }
 
 // FindAll chocolates
-func (c ChocolateResource) FindAll(r api2go.Request) (interface{}, error) {
+func (c ChocolateResource) FindAll(r api2go.Request) (api2go.Responder, error) {
 	usersID, ok := r.QueryParams["usersID"]
 	sweets := c.ChocStorage.GetAll()
 	if ok {
@@ -27,50 +27,52 @@ func (c ChocolateResource) FindAll(r api2go.Request) (interface{}, error) {
 		filteredSweets := []model.Chocolate{}
 		user, err := c.UserStorage.GetOne(userID)
 		if err != nil {
-			return "", err
+			return &Response{}, err
 		}
 		for _, sweetID := range user.ChocolatesIDs {
 			sweet, err := c.ChocStorage.GetOne(sweetID)
 			if err != nil {
-				return "", err
+				return &Response{}, err
 			}
 			filteredSweets = append(filteredSweets, sweet)
 		}
 
-		return filteredSweets, nil
+		return &Response{Res: filteredSweets}, nil
 	}
-	return sweets, nil
+	return &Response{Res: sweets}, nil
 }
 
 // FindOne choc
-func (c ChocolateResource) FindOne(ID string, r api2go.Request) (interface{}, error) {
-	return c.ChocStorage.GetOne(ID)
+func (c ChocolateResource) FindOne(ID string, r api2go.Request) (api2go.Responder, error) {
+	res, err := c.ChocStorage.GetOne(ID)
+	return &Response{Res: res}, err
 }
 
 // Create a new choc
-func (c ChocolateResource) Create(obj interface{}, r api2go.Request) (string, int, error) {
+func (c ChocolateResource) Create(obj interface{}, r api2go.Request) (api2go.Responder, error) {
 	choc, ok := obj.(model.Chocolate)
 	if !ok {
-		return "", 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return &Response{}, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
 	id := c.ChocStorage.Insert(choc)
-	return id, http.StatusCreated, nil
+	choc.ID = id
+	return &Response{Res: choc, Code: http.StatusCreated}, nil
 }
 
 // Delete a choc :(
-func (c ChocolateResource) Delete(id string, r api2go.Request) (int, error) {
+func (c ChocolateResource) Delete(id string, r api2go.Request) (api2go.Responder, error) {
 	err := c.ChocStorage.Delete(id)
-	return http.StatusNoContent, err
+	return &Response{Code: http.StatusOK}, err
 }
 
 // Update a choc
-func (c ChocolateResource) Update(obj interface{}, r api2go.Request) (int, error) {
+func (c ChocolateResource) Update(obj interface{}, r api2go.Request) (api2go.Responder, error) {
 	choc, ok := obj.(model.Chocolate)
 	if !ok {
-		return 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return &Response{}, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
 	err := c.ChocStorage.Update(choc)
-	return http.StatusNoContent, err
+	return &Response{Res: choc, Code: http.StatusNoContent}, err
 }

--- a/examples/resource/resource_user.go
+++ b/examples/resource/resource_user.go
@@ -134,28 +134,30 @@ func (s UserResource) FindOne(ID string, r api2go.Request) (interface{}, error) 
 }
 
 // Create method to satisfy `api2go.DataSource` interface
-func (s UserResource) Create(obj interface{}, r api2go.Request) (string, error) {
+func (s UserResource) Create(obj interface{}, r api2go.Request) (string, int, error) {
 	user, ok := obj.(model.User)
 	if !ok {
-		return "", api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return "", 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
 	id := s.UserStorage.Insert(user)
 
-	return id, nil
+	return id, http.StatusCreated, nil
 }
 
 // Delete to satisfy `api2go.DataSource` interface
-func (s UserResource) Delete(id string, r api2go.Request) error {
-	return s.UserStorage.Delete(id)
+func (s UserResource) Delete(id string, r api2go.Request) (int, error) {
+	err := s.UserStorage.Delete(id)
+	return http.StatusNoContent, err
 }
 
 //Update stores all changes on the user
-func (s UserResource) Update(obj interface{}, r api2go.Request) error {
+func (s UserResource) Update(obj interface{}, r api2go.Request) (int, error) {
 	user, ok := obj.(model.User)
 	if !ok {
-		return api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
-	return s.UserStorage.Update(user)
+	err := s.UserStorage.Update(user)
+	return http.StatusNoContent, err
 }

--- a/examples/resource/resource_user.go
+++ b/examples/resource/resource_user.go
@@ -18,7 +18,7 @@ type UserResource struct {
 }
 
 // FindAll to satisfy api2go data source interface
-func (s UserResource) FindAll(r api2go.Request) (interface{}, error) {
+func (s UserResource) FindAll(r api2go.Request) (api2go.Responder, error) {
 	var result []model.User
 	users := s.UserStorage.GetAll()
 
@@ -28,18 +28,18 @@ func (s UserResource) FindAll(r api2go.Request) (interface{}, error) {
 		for _, chocolateID := range user.ChocolatesIDs {
 			choc, err := s.ChocStorage.GetOne(chocolateID)
 			if err != nil {
-				return "", err
+				return &Response{}, err
 			}
 			user.Chocolates = append(user.Chocolates, &choc)
 		}
 		result = append(result, *user)
 	}
 
-	return result, nil
+	return &Response{Res: result}, nil
 }
 
 // PaginatedFindAll can be used to load users in chunks
-func (s UserResource) PaginatedFindAll(r api2go.Request) (interface{}, uint, error) {
+func (s UserResource) PaginatedFindAll(r api2go.Request) (uint, api2go.Responder, error) {
 	var (
 		result                      []model.User
 		number, size, offset, limit string
@@ -50,7 +50,7 @@ func (s UserResource) PaginatedFindAll(r api2go.Request) (interface{}, uint, err
 	for k := range users {
 		i, err := strconv.ParseInt(k, 10, 64)
 		if err != nil {
-			return nil, 0, err
+			return 0, &Response{}, err
 		}
 
 		keys = append(keys, int(i))
@@ -77,12 +77,12 @@ func (s UserResource) PaginatedFindAll(r api2go.Request) (interface{}, uint, err
 	if size != "" {
 		sizeI, err := strconv.ParseUint(size, 10, 64)
 		if err != nil {
-			return nil, 0, err
+			return 0, &Response{}, err
 		}
 
 		numberI, err := strconv.ParseUint(number, 10, 64)
 		if err != nil {
-			return nil, 0, err
+			return 0, &Response{}, err
 		}
 
 		start := sizeI * (numberI - 1)
@@ -95,12 +95,12 @@ func (s UserResource) PaginatedFindAll(r api2go.Request) (interface{}, uint, err
 	} else {
 		limitI, err := strconv.ParseUint(limit, 10, 64)
 		if err != nil {
-			return nil, 0, err
+			return 0, &Response{}, err
 		}
 
 		offsetI, err := strconv.ParseUint(offset, 10, 64)
 		if err != nil {
-			return nil, 0, err
+			return 0, &Response{}, err
 		}
 
 		for i := offsetI; i < offsetI+limitI; i++ {
@@ -111,53 +111,54 @@ func (s UserResource) PaginatedFindAll(r api2go.Request) (interface{}, uint, err
 		}
 	}
 
-	return result, uint(len(users)), nil
+	return uint(len(users)), &Response{Res: result}, nil
 }
 
 // FindOne to satisfy `api2go.DataSource` interface
 // this method should return the user with the given ID, otherwise an error
-func (s UserResource) FindOne(ID string, r api2go.Request) (interface{}, error) {
+func (s UserResource) FindOne(ID string, r api2go.Request) (api2go.Responder, error) {
 	user, err := s.UserStorage.GetOne(ID)
 	if err != nil {
-		return "", err
+		return &Response{}, err
 	}
 
 	user.Chocolates = []*model.Chocolate{}
 	for _, chocolateID := range user.ChocolatesIDs {
 		choc, err := s.ChocStorage.GetOne(chocolateID)
 		if err != nil {
-			return "", err
+			return &Response{}, err
 		}
 		user.Chocolates = append(user.Chocolates, &choc)
 	}
-	return user, nil
+	return &Response{Res: user}, nil
 }
 
 // Create method to satisfy `api2go.DataSource` interface
-func (s UserResource) Create(obj interface{}, r api2go.Request) (string, int, error) {
+func (s UserResource) Create(obj interface{}, r api2go.Request) (api2go.Responder, error) {
 	user, ok := obj.(model.User)
 	if !ok {
-		return "", 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return &Response{}, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
 	id := s.UserStorage.Insert(user)
+	user.ID = id
 
-	return id, http.StatusCreated, nil
+	return &Response{Res: user, Code: http.StatusCreated}, nil
 }
 
 // Delete to satisfy `api2go.DataSource` interface
-func (s UserResource) Delete(id string, r api2go.Request) (int, error) {
+func (s UserResource) Delete(id string, r api2go.Request) (api2go.Responder, error) {
 	err := s.UserStorage.Delete(id)
-	return http.StatusNoContent, err
+	return &Response{Code: http.StatusNoContent}, err
 }
 
 //Update stores all changes on the user
-func (s UserResource) Update(obj interface{}, r api2go.Request) (int, error) {
+func (s UserResource) Update(obj interface{}, r api2go.Request) (api2go.Responder, error) {
 	user, ok := obj.(model.User)
 	if !ok {
-		return 0, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
+		return &Response{}, api2go.NewHTTPError(errors.New("Invalid instance given"), "Invalid instance given", http.StatusBadRequest)
 	}
 
 	err := s.UserStorage.Update(user)
-	return http.StatusNoContent, err
+	return &Response{Res: user, Code: http.StatusNoContent}, err
 }

--- a/examples/resource/response.go
+++ b/examples/resource/response.go
@@ -6,8 +6,8 @@ type Response struct {
 	Code int
 }
 
-// MetaData returns additional meta data
-func (r *Response) MetaData() map[string]interface{} {
+// Metadata returns additional meta data
+func (r Response) Metadata() map[string]interface{} {
 	return map[string]interface{}{
 		"author":      "The api2go examples crew",
 		"license":     "wtfpl",
@@ -16,11 +16,11 @@ func (r *Response) MetaData() map[string]interface{} {
 }
 
 // Result returns the actual payload
-func (r *Response) Result() interface{} {
+func (r Response) Result() interface{} {
 	return r.Res
 }
 
 // StatusCode sets the return status code
-func (r *Response) StatusCode() int {
+func (r Response) StatusCode() int {
 	return r.Code
 }

--- a/examples/resource/response.go
+++ b/examples/resource/response.go
@@ -1,0 +1,26 @@
+package resource
+
+// The Response struct implements api2go.Responder
+type Response struct {
+	Res  interface{}
+	Code int
+}
+
+// MetaData returns additional meta data
+func (r *Response) MetaData() map[string]interface{} {
+	return map[string]interface{}{
+		"author":      "The api2go examples crew",
+		"license":     "wtfpl",
+		"license-url": "http://www.wtfpl.net",
+	}
+}
+
+// Result returns the actual payload
+func (r *Response) Result() interface{} {
+	return r.Res
+}
+
+// StatusCode sets the return status code
+func (r *Response) StatusCode() int {
+	return r.Code
+}


### PR DESCRIPTION
Create, Update and Delete methods now support an additional return code. In
case of an error, the error return type with a 400 or 500 return code must be
used. In case of success, the int return code can be used.

Whenever an updated response must be sent, the FindOne method is automatically called by the API. 

There is one thing where I do not know how to solve it best, it's the 200 OK Status for Delete. It should be possible to only return some meta data here. Any suggestions?

Resolves #138 
Resolves #86 

Todo:
- [x] Always include meta struct
- [x] Update Readme
- [x] Refactor switch with status codes