### PR TITLE
Add a QueryParam with the Name of the Reference

### DIFF
--- a/api.go
+++ b/api.go
@@ -425,6 +425,7 @@ func (res *resource) handleLinked(api *API, w http.ResponseWriter, r *http.Reque
 		if resource.name == linked.Type {
 			request := buildRequest(r)
 			request.QueryParams[res.name+"ID"] = []string{id}
+			request.QueryParams[res.name+"Name"] = []string{linked.Name}
 
 			// check for pagination, otherwise normal FindAll
 			pagination := newPaginationQueryParams(r)


### PR DESCRIPTION
When the API call the findAll method it can be useful to know the Reference Name. If you have a single model with multiple property linked to the same reference type (per ex. a model People, can be linked as Director and Producer in a Film).