### PR TITLE
fix slice unmarshal

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -308,6 +308,12 @@ func (i Identity) GetID() string {
 	return fmt.Sprintf("%d", i.ID)
 }
 
+func (i *Identity) SetID(ID string) error {
+	var err error
+	i.ID, err = strconv.ParseInt(ID, 10, 64)
+	return err
+}
+
 type Unicorn struct {
 	UnicornID int64    `json:"unicorn_id"` //Annotations are ignored
 	Scopes    []string `json:"scopes"`

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -334,6 +334,27 @@ func setFieldValue(field *reflect.Value, value reflect.Value) (err error) {
 		field.SetInt(int64(value.Float()))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		field.SetUint(uint64(value.Float()))
+	case reflect.Slice:
+		// we always get a []interface{] from json and now need to cast to the right slice type
+		if value.Type() == reflect.TypeOf([]interface{}{}) {
+			targetSlice := reflect.MakeSlice(field.Type(), 0, value.Len())
+			sliceData := value.Interface().([]interface{})
+
+			// only iterate over the array if it's not empty
+			if value.Len() > 0 {
+				targetType := reflect.TypeOf(sliceData[0])
+				for _, entry := range sliceData {
+					casted := reflect.ValueOf(entry).Convert(targetType)
+					targetSlice = reflect.Append(targetSlice, casted)
+				}
+			}
+
+			field.Set(targetSlice)
+		} else {
+			// we have the correct type, hm this is only for tests that use direct type at the moment.. we have to refactor the unmarshalling
+			// anyways..
+			field.Set(value)
+		}
 	default:
 		// try to set it with json.Unmarshaler interface, if that does not work, set value directly
 		switch target := field.Addr().Interface().(type) {

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -164,6 +164,67 @@ var _ = Describe("Unmarshal", func() {
 			Expect(err).To(BeNil())
 			Expect(posts).To(Equal([]SimplePost{firstPost}))
 		})
+
+		Context("slice fields", func() {
+			It("unmarshal slice fields correctly", func() {
+				sliceMap := map[string]interface{}{
+					"data": map[string]interface{}{
+						"id":   "1234",
+						"type": "identities",
+						"attributes": map[string]interface{}{
+							"scopes": []string{
+								"user_global",
+							},
+						},
+					},
+				}
+
+				var identity Identity
+				err := Unmarshal(sliceMap, &identity)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(identity.Scopes).To(HaveLen(1))
+				Expect(identity.Scopes[0]).To(Equal("user_global"))
+			})
+
+			It("unmarshal slice fields from json input", func() {
+				input := `
+					{
+						"data": {
+							"id": "1234",
+							"type": "identities",
+							"attributes": {
+								"scopes": ["test", "1234"]
+							}
+						}
+					}
+				`
+
+				var identity Identity
+				err := UnmarshalFromJSON([]byte(input), &identity)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(identity.Scopes[0]).To(Equal("test"))
+				Expect(identity.Scopes[1]).To(Equal("1234"))
+			})
+
+			It("unmarshal empty slice fields from json input", func() {
+				input := `
+					{
+						"data": {
+							"id": "1234",
+							"type": "identities",
+							"attributes": {
+								"scopes": []
+							}
+						}
+					}
+				`
+
+				var identity Identity
+				err := UnmarshalFromJSON([]byte(input), &identity)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(identity.Scopes).To(Equal([]string{}))
+			})
+		})
 	})
 
 	Context("when unmarshaling objects with relationships", func() {


### PR DESCRIPTION
we did not test it with real json data. The problem was that our current unmarshal implementation always get's an `[]interface{}` and not the desired target type. Until we have a better unmarshaling, this is a fix for that.