### PR TITLE
use `jsonapi:"-"` tag to ignore fields, fixes #171

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ comments that belong with a has-many relation to the post.
 
 ```go
 type Post struct {
-  ID          int
+  ID          int       `jsonapi:"-"` // Ignore ID field because the ID is fetched via the
+                                      // GetID() method and must not be inside the attributes object.
   Title       string
-  Comments    []Comment `json:"-"` // this will be ignored by the api2go marshaller
-  CommentsIDs []int     `json:"-"` // it's only useful for our internal relationship handling
+  Comments    []Comment `jsonapi:"-"` // this will be ignored by the api2go marshaller
+  CommentsIDs []int     `jsonapi:"-"` // it's only useful for our internal relationship handling
 }
 
 type Comment struct {
@@ -65,8 +66,9 @@ You must at least implement one interface for api2go to work, which is the one f
 that you want to marshal/unmarshal. This is because of the huge variety of types that you could  use for the primary ID. For example a string,
 a UUID or a BSON Object for MongoDB etc...
 
-If the struct already has a field named `ID`, or `Id`, it will be ignored automatically. If your ID field has a different name, please use the
-json ignore tag. Api2go will use the `GetID` method that you implemented for your struct to fetch the ID of the struct.
+In the Post example struct, the `ID` field is ignored because Api2go will use the `GetID` method that you implemented for your struct to fetch the ID of the struct.
+Every field inside a struct will be marshaled into the `attributes` object in
+the json. In our example, we just want to have the `Title` field there.
 
 In order to use different internal names for elements, you can specify a jsonapi tag. The api will marshal results now with the name in the tag.
 Create/Update/Delete works accordingly, but will fallback to the internal value as well if possible.

--- a/api_entity_name_test.go
+++ b/api_entity_name_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type BaguetteTaste struct {
-	ID    string `json:"-"`
+	ID    string `jsonapi:"-"`
 	Taste string
 }
 

--- a/api_interfaces_test.go
+++ b/api_interfaces_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type SomeData struct {
-	ID         string `json:"-"`
+	ID         string `jsonapi:"-"`
 	Data       string
 	CustomerID string `jsonapi:"name=customerId"`
 }

--- a/api_test.go
+++ b/api_test.go
@@ -41,12 +41,12 @@ func (r Response) StatusCode() int {
 }
 
 type Post struct {
-	ID       string `json:"-"`
+	ID       string `jsonapi:"-"`
 	Title    string
 	Value    null.Float
-	Author   *User     `json:"-"`
-	Comments []Comment `json:"-"`
-	Bananas  []Banana  `json:"-"`
+	Author   *User     `jsonapi:"-"`
+	Comments []Comment `jsonapi:"-"`
+	Bananas  []Banana  `jsonapi:"-"`
 }
 
 func (p Post) GetID() string {
@@ -181,7 +181,7 @@ func (p Post) GetReferencedStructs() []jsonapi.MarshalIdentifier {
 }
 
 type Comment struct {
-	ID    string `json:"-"`
+	ID    string `jsonapi:"-"`
 	Value string
 }
 
@@ -199,7 +199,7 @@ func (b Banana) GetID() string {
 }
 
 type User struct {
-	ID   string `json:"-"`
+	ID   string `jsonapi:"-"`
 	Name string
 }
 

--- a/examples/crud_example_test.go
+++ b/examples/crud_example_test.go
@@ -53,7 +53,6 @@ var _ = Describe("CrudExample", func() {
 				"id": "1",
 				"type": "users",
 				"attributes": {
-					"id": "1",
 					"user-name": "marvin"
 				},
 				"relationships": {
@@ -144,7 +143,6 @@ var _ = Describe("CrudExample", func() {
 			},
 			"data": {
 				"attributes": {
-					"id": "1",
 					"user-name": "marvin"
 				},
 				"id": "1",
@@ -219,7 +217,6 @@ var _ = Describe("CrudExample", func() {
 			},
 			"data": {
 				"attributes": {
-					"id": "1",
 					"user-name": "marvin"
 				},
 				"id": "1",
@@ -272,7 +269,6 @@ var _ = Describe("CrudExample", func() {
 			},
 			"data": {
 				"attributes": {
-					"id": "1",
 					"user-name": "marvin"
 				},
 				"id": "1",
@@ -397,7 +393,6 @@ var _ = Describe("CrudExample", func() {
 				},
 				"data": {
 					"attributes": {
-						"id": "1",
 						"user-name": "marvin"
 					},
 					"id": "1",

--- a/examples/model/model_chocolate.go
+++ b/examples/model/model_chocolate.go
@@ -2,7 +2,7 @@ package model
 
 // Chocolate is the chocolate that a user consumes in order to get fat and happy
 type Chocolate struct {
-	ID    string `json:"-"`
+	ID    string `jsonapi:"-"`
 	Name  string
 	Taste string
 }

--- a/examples/model/model_user.go
+++ b/examples/model/model_user.go
@@ -8,12 +8,12 @@ import (
 
 // User is a generic database user
 type User struct {
-	ID string
+	ID string `jsonapi:"-"`
 	//rename the username field to user-name.
 	Username      string       `jsonapi:"name=user-name"`
-	PasswordHash  string       `json:"-"`
-	Chocolates    []*Chocolate `json:"-"`
-	ChocolatesIDs []string     `json:"-"`
+	PasswordHash  string       `jsonapi:"-"`
+	Chocolates    []*Chocolate `jsonapi:"-"`
+	ChocolatesIDs []string     `jsonapi:"-"`
 	exists        bool
 }
 

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -68,6 +68,7 @@ func (u *User) SetID(stringID string) error {
 type SimplePost struct {
 	ID          string `jsonapi:"-"`
 	Title, Text string
+	Internal    string `jsonapi:"-"`
 	Size        int
 	Created     time.Time `jsonapi:"name=create-date"`
 }

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Magic struct {
-	ID MagicID `json:"-"`
+	ID MagicID `jsonapi:"-"`
 }
 
 func (m Magic) GetID() string {
@@ -25,7 +25,7 @@ func (m MagicID) String() string {
 }
 
 type Comment struct {
-	ID   int `json:"-"`
+	ID   int `jsonapi:"-"`
 	Text string
 }
 
@@ -45,9 +45,9 @@ func (c *Comment) SetID(stringID string) error {
 }
 
 type User struct {
-	ID       int `json:"-"`
+	ID       int `jsonapi:"-"`
 	Name     string
-	Password string `json:"-"`
+	Password string `jsonapi:"-"`
 }
 
 func (u User) GetID() string {
@@ -66,7 +66,7 @@ func (u *User) SetID(stringID string) error {
 }
 
 type SimplePost struct {
-	ID          string `json:"-"`
+	ID          string `jsonapi:"-"`
 	Title, Text string
 	Size        int
 	Created     time.Time `jsonapi:"name=create-date"`
@@ -83,14 +83,14 @@ func (s *SimplePost) SetID(ID string) error {
 }
 
 type Post struct {
-	ID            int `json:"-"`
+	ID            int `jsonapi:"-"`
 	Title         string
-	Comments      []Comment     `json:"-"`
-	CommentsIDs   []int         `json:"-"`
-	CommentsEmpty bool          `json:"-"`
-	Author        *User         `json:"-"`
-	AuthorID      sql.NullInt64 `json:"-"`
-	AuthorEmpty   bool          `json:"-"`
+	Comments      []Comment     `jsonapi:"-"`
+	CommentsIDs   []int         `jsonapi:"-"`
+	CommentsEmpty bool          `jsonapi:"-"`
+	Author        *User         `jsonapi:"-"`
+	AuthorID      sql.NullInt64 `jsonapi:"-"`
+	AuthorEmpty   bool          `jsonapi:"-"`
 }
 
 func (c Post) GetID() string {
@@ -213,9 +213,9 @@ func (c *Post) SetReferencedStructs(references []UnmarshalIdentifier) error {
 }
 
 type AnotherPost struct {
-	ID       int   `json:"-"`
-	AuthorID int   `json:"-"`
-	Author   *User `json:"-"`
+	ID       int   `jsonapi:"-"`
+	AuthorID int   `jsonapi:"-"`
+	Author   *User `jsonapi:"-"`
 }
 
 func (p AnotherPost) GetID() string {
@@ -242,7 +242,7 @@ func (p AnotherPost) GetReferencedIDs() []ReferenceID {
 }
 
 type ZeroPost struct {
-	ID    string `json:"-"`
+	ID    string `jsonapi:"-"`
 	Title string
 	Value zero.Float
 }
@@ -252,7 +252,7 @@ func (z ZeroPost) GetID() string {
 }
 
 type ZeroPostPointer struct {
-	ID    string `json:"-"`
+	ID    string `jsonapi:"-"`
 	Title string
 	Value *zero.Float
 }
@@ -262,10 +262,10 @@ func (z ZeroPostPointer) GetID() string {
 }
 
 type Question struct {
-	ID                  string `json:"-"`
+	ID                  string `jsonapi:"-"`
 	Text                string
-	InspiringQuestionID sql.NullString `json:"-"`
-	InspiringQuestion   *Question      `json:"-"`
+	InspiringQuestionID sql.NullString `jsonapi:"-"`
+	InspiringQuestion   *Question      `jsonapi:"-"`
 }
 
 func (q Question) GetID() string {
@@ -300,7 +300,7 @@ func (q Question) GetReferencedStructs() []MarshalIdentifier {
 }
 
 type Identity struct {
-	ID     int64    `json:"-"`
+	ID     int64    `jsonapi:"-"`
 	Scopes []string `json:"scopes"`
 }
 
@@ -324,7 +324,7 @@ func (u Unicorn) GetID() string {
 }
 
 type NumberPost struct {
-	ID             string `json:"-"`
+	ID             string `jsonapi:"-"`
 	Title          string
 	Number         int64
 	UnsignedNumber uint64
@@ -337,7 +337,7 @@ func (n *NumberPost) SetID(ID string) error {
 }
 
 type SQLNullPost struct {
-	ID     string `json:"-"`
+	ID     string `jsonapi:"-"`
 	Title  zero.String
 	Likes  zero.Int
 	Rating zero.Float

--- a/jsonapi/integration_test.go
+++ b/jsonapi/integration_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Book struct {
-	ID       string      `json:"-"`
-	Author   *StupidUser `json:"-"`
-	AuthorID string      `json:"-"`
-	Pages    []Page      `json:"-"`
-	PagesIDs []string    `json:"-"`
+	ID       string      `jsonapi:"-"`
+	Author   *StupidUser `jsonapi:"-"`
+	AuthorID string      `jsonapi:"-"`
+	Pages    []Page      `jsonapi:"-"`
+	PagesIDs []string    `jsonapi:"-"`
 }
 
 func (b Book) GetID() string {
@@ -84,7 +84,7 @@ func (b Book) GetReferencedStructs() []MarshalIdentifier {
 }
 
 type StupidUser struct {
-	ID   string `json:"-"`
+	ID   string `jsonapi:"-"`
 	Name string
 }
 
@@ -93,7 +93,7 @@ func (s StupidUser) GetID() string {
 }
 
 type Page struct {
-	ID      string `json:"-"`
+	ID      string `jsonapi:"-"`
 	Content string
 }
 

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -387,7 +387,7 @@ func getStructFields(data MarshalIdentifier) map[string]interface{} {
 	}
 	valType := val.Type()
 	for i := 0; i < val.NumField(); i++ {
-		tag := valType.Field(i).Tag.Get("json")
+		tag := valType.Field(i).Tag.Get("jsonapi")
 		if tag == "-" {
 			continue
 		}

--- a/jsonapi/marshal_enum_test.go
+++ b/jsonapi/marshal_enum_test.go
@@ -55,7 +55,7 @@ func (s *PublishStatus) UnmarshalJSON(data []byte) error {
 }
 
 type EnumPost struct {
-	ID     string `json:"-"`
+	ID     string `jsonapi:"-"`
 	Title  string
 	Status PublishStatus
 }

--- a/jsonapi/marshal_same_type_test.go
+++ b/jsonapi/marshal_same_type_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Node struct {
-	ID                string `json:"-"`
+	ID                string `jsonapi:"-"`
 	Content           string
-	MotherID          string   `json:"-"`
-	ChildIDs          []string `json:"-"`
-	AbandonedChildIDs []string `json:"-"`
+	MotherID          string   `jsonapi:"-"`
+	ChildIDs          []string `jsonapi:"-"`
+	AbandonedChildIDs []string `jsonapi:"-"`
 }
 
 func (n *Node) GetID() string {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -256,19 +256,20 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 					fieldName := Dejsonify(key)
 					field := val.FieldByName(fieldName)
 					fieldType, found := val.Type().FieldByName(fieldName)
-					if !found || found && fieldType.Tag.Get("jsonapi") == "-" {
+					if !found {
 						//check if there is any field tag with the given name available
 						for x := 0; x < val.NumField(); x++ {
 							tfield := val.Type().Field(x)
 							name := GetTagValueByName(tfield, "name")
 							if tfield.Tag.Get("jsonapi") != "-" && strings.ToLower(name) == strings.ToLower(fieldName) {
 								field = val.Field(x)
+								found = true
 							}
 						}
 
-						if !field.IsValid() {
-							return errors.New("expected struct " + targetStructType.Name() + " to have field " + fieldName)
-						}
+					}
+					if !found || fieldType.Tag.Get("jsonapi") == "-" {
+						return fmt.Errorf("invalid key \"%s\" in json. Cannot be assigned to target struct \"%s\"", key, targetStructType.Name())
 					}
 
 					value := reflect.ValueOf(attributeValue)

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -255,12 +255,13 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 				for key, attributeValue := range attributes {
 					fieldName := Dejsonify(key)
 					field := val.FieldByName(fieldName)
-					if !field.IsValid() {
+					fieldType, found := val.Type().FieldByName(fieldName)
+					if !found || found && fieldType.Tag.Get("jsonapi") == "-" {
 						//check if there is any field tag with the given name available
 						for x := 0; x < val.NumField(); x++ {
 							tfield := val.Type().Field(x)
 							name := GetTagValueByName(tfield, "name")
-							if strings.ToLower(name) == strings.ToLower(fieldName) {
+							if tfield.Tag.Get("jsonapi") != "-" && strings.ToLower(name) == strings.ToLower(fieldName) {
 								field = val.Field(x)
 							}
 						}

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -125,6 +125,21 @@ var _ = Describe("Unmarshal", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("errors if a field is in the json that is ignored by the struct", func() {
+			var post SimplePost
+			err := Unmarshal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id": "1234",
+					"attributes": map[string]interface{}{
+						"title":    "something",
+						"text":     "blubb",
+						"internal": "1337",
+					},
+				},
+			}, &post)
+			Expect(err.Error()).To(Equal("invalid key \"internal\" in json. Cannot be assigned to target struct \"SimplePost\""))
+		})
+
 		It("errors with wrong type, expected int, got a string", func() {
 			var posts []SimplePost
 			err := Unmarshal(map[string]interface{}{


### PR DESCRIPTION
also fixed a model in the examples project which forgot to ignore the ID
field. Tests were wrong too and expected an id field inside attributes.