### PR TITLE
api2go.Response as default for api2go.Responder

### DIFF
--- a/api_public.go
+++ b/api_public.go
@@ -121,3 +121,28 @@ func (m JSONContentMarshaler) Marshal(i interface{}) ([]byte, error) {
 func (m JSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
 	return json.Unmarshal(data, i)
 }
+
+//The Response struct implements api2go.Responder and can be used as a default
+//implementation for your responses
+//you can fill the field `Meta` with all the metadata your application needs
+//like license, tokens, etc
+type Response struct {
+	Res  interface{}
+	Code int
+	Meta map[string]interface{}
+}
+
+// Metadata returns additional meta data
+func (r Response) Metadata() map[string]interface{} {
+	return r.Meta
+}
+
+// Result returns the actual payload
+func (r Response) Result() interface{} {
+	return r.Res
+}
+
+// StatusCode sets the return status code
+func (r Response) StatusCode() int {
+	return r.Code
+}

--- a/api_test.go
+++ b/api_test.go
@@ -22,24 +22,6 @@ func (i invalid) GetID() string {
 	return "invalid"
 }
 
-type Response struct {
-	Meta map[string]interface{}
-	Res  interface{}
-	Code int
-}
-
-func (r Response) Metadata() map[string]interface{} {
-	return r.Meta
-}
-
-func (r Response) Result() interface{} {
-	return r.Res
-}
-
-func (r Response) StatusCode() int {
-	return r.Code
-}
-
 type Post struct {
 	ID       string `jsonapi:"-"`
 	Title    string


### PR DESCRIPTION
This can be useful for very basic applications that don't require a special `api2go.Responder` implementation