### PR TITLE
Fix build error: cannot use notAllowedHandler literal as http.HandlerFunc

### DIFF
--- a/api_public.go
+++ b/api_public.go
@@ -94,7 +94,7 @@ func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]C
 	}
 
 	router := httprouter.New()
-	router.MethodNotAllowed = notAllowedHandler{marshalers: marshalers}
+	router.MethodNotAllowed = notAllowedHandler{marshalers: marshalers}.ServeHTTP
 
 	info := information{prefix: prefix, baseURL: baseURL}
 


### PR DESCRIPTION
This fixes https://github.com/manyminds/api2go/issues/177