### PR TITLE
[WIP] Two new interfaces for baseurl resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ go get github.com/manyminds/api2go/jsonapi
   - [Fetching related IDs](#fetching-related-ids)
   - [Fetching related resources](#fetching-related-resources)
   - [Using middleware](#using-middleware)
+  - [Dynamic URL Handling](#dynamic-url-handling)
 - [Tests](#tests)
 
 ## Examples
@@ -567,6 +568,32 @@ registered with `func (api *API) UseMiddleware(middleware ...HandlerFunc)`. You 
 that will be executed in order before any other api2go routes. Use this to set up database connections, user authentication
 and so on.
 
+### Dynamic URL handling
+If you have different TLDs for one api, or want to use different domains in development and production, you can implement a custom
+URLResolver in api2go. 
+
+There is a simple interface, which can be used if you get TLD information from the database, the server environment, or anything else
+that's not request dependant:
+```go
+type URLResolver interface {
+	GetBaseURL() string
+}
+```
+And a more complex one that also gets request information:
+```go
+type RequestAwareURLResolver interface {
+	URLResolver
+	SetRequest(http.Request)
+}
+```
+
+For most use cases we provide a CallbackResolver which works on a per request basis and may fill
+your basic needs. This is particulary useful if you are using an nginx proxy which sets `X-Forwarded-For` headers.
+
+```go
+resolver := NewCallbackResolver(func(r http.Request) string{})
+api := NewApiWithMarshalling("v1", resolver, marshalers)
+```
 ## Tests
 
 ```sh

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -1,5 +1,7 @@
 package api2go
 
+import "net/http"
+
 // The CRUD interface MUST be implemented in order to use the api2go api.
 type CRUD interface {
 	// FindOne returns an object by its ID
@@ -52,6 +54,29 @@ type PaginatedFindAll interface {
 type FindAll interface {
 	// FindAll returns all objects
 	FindAll(req Request) (Responder, error)
+}
+
+//URLResolver allows you to implement a static
+//way to return a baseURL for all incoming
+//requests for one api2go instance.
+type URLResolver interface {
+	GetBaseURL() string
+}
+
+//RequestAwareURLResolver allows you to dynamically change
+//generated urls.
+//
+//This is particulary useful if you have the same
+//API answering to multiple domains, or subdomains
+//e.g customer[1,2,3,4].yourapi.example.com
+//
+//SetRequest will always be called prior to
+//the GetBaseURL() from `URLResolver` so you
+//have to change the result value based on the last
+//request.
+type RequestAwareURLResolver interface {
+	URLResolver
+	SetRequest(http.Request)
 }
 
 // The Responder interface is used by all Resource Methods as a container for the Response.

--- a/api_public.go
+++ b/api_public.go
@@ -73,14 +73,21 @@ func (api *API) SetRedirectTrailingSlash(enabled bool) {
 	api.router.RedirectTrailingSlash = enabled
 }
 
-// NewAPIWithMarshalers does the same as NewAPIWithBaseURL with the addition
+//NewAPIWithMarshalers is DEPRECATED
+//use NewApiWithMarshalling instead
+func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]ContentMarshaler) *API {
+	staticResolver := newStaticResolver(baseURL)
+	return NewAPIWithMarshalling(prefix, staticResolver, marshalers)
+}
+
+// NewAPIWithMarshalling does the same as NewAPIWithBaseURL with the addition
 // of a set of marshalers that provide a way to interact with clients that
 // use a serialization format other than JSON. The marshalers map is indexed
 // by the MIME content type to use for a given request-response pair. If the
 // client provides an Accept header the server will respond using the client's
 // preferred content type, otherwise it will respond using whatever content
 // type the client provided in its Content-Type request header.
-func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]ContentMarshaler) *API {
+func NewAPIWithMarshalling(prefix string, resolver URLResolver, marshalers map[string]ContentMarshaler) *API {
 	if len(marshalers) == 0 {
 		panic("marshaler map must not be empty")
 	}
@@ -96,7 +103,7 @@ func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]C
 	router := httprouter.New()
 	router.MethodNotAllowed = notAllowedHandler{marshalers: marshalers}
 
-	info := information{prefix: prefix, baseURL: baseURL}
+	info := information{prefix: prefix, resolver: resolver}
 
 	api := &API{
 		router:           router,

--- a/examples/resolver/resolver.go
+++ b/examples/resolver/resolver.go
@@ -1,0 +1,28 @@
+package resolver
+
+import (
+	"fmt"
+	"net/http"
+)
+
+//RequestURL simply returns
+//the request url from REQUEST_URI header
+//this should not be done in production applications
+type RequestURL struct {
+	r    http.Request
+	Port int
+}
+
+//SetRequest to implement `RequestAwareResolverInterface`
+func (m *RequestURL) SetRequest(r http.Request) {
+	m.r = r
+}
+
+//GetBaseURL implements `URLResolver` interface
+func (m RequestURL) GetBaseURL() string {
+	if uri := m.r.Header.Get("REQUEST_URI"); uri != "" {
+		return uri
+	}
+
+	return fmt.Sprintf("https://localhost:%d", m.Port)
+}

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // MarshalIdentifier interface is necessary to give an element
@@ -301,25 +302,18 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 // helper method to generate URL fields for `links`
 func getLinksForServerInformation(relationer MarshalLinkedRelations, name string, information ServerInformation) map[string]string {
 	links := map[string]string{}
-	// generate links if necessary
+
 	if information != serverInformationNil {
-		prefix := ""
-		baseURL := information.GetBaseURL()
-		if baseURL != "" {
-			prefix = baseURL
-		}
-		p := information.GetPrefix()
-		if p != "" {
-			prefix += "/" + p
+		prefix := strings.Trim(information.GetBaseURL(), "/")
+		namespace := strings.Trim(information.GetPrefix(), "/")
+		structType := getStructType(relationer)
+
+		if namespace != "" {
+			prefix += "/" + namespace
 		}
 
-		if prefix != "" {
-			links["self"] = fmt.Sprintf("%s/%s/%s/relationships/%s", prefix, getStructType(relationer), relationer.GetID(), name)
-			links["related"] = fmt.Sprintf("%s/%s/%s/%s", prefix, getStructType(relationer), relationer.GetID(), name)
-		} else {
-			links["self"] = fmt.Sprintf("/%s/%s/relationships/%s", getStructType(relationer), relationer.GetID(), name)
-			links["related"] = fmt.Sprintf("/%s/%s/%s", getStructType(relationer), relationer.GetID(), name)
-		}
+		links["self"] = fmt.Sprintf("%s/%s/%s/relationships/%s", prefix, structType, relationer.GetID(), name)
+		links["related"] = fmt.Sprintf("%s/%s/%s/%s", prefix, structType, relationer.GetID(), name)
 	}
 
 	return links

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,16 @@
+package api2go
+
+//staticResolver is only used
+//for backwards compatible reasons
+//and might be removed in the future
+type staticResolver struct {
+	baseURL string
+}
+
+func (s staticResolver) GetBaseURL() string {
+	return s.baseURL
+}
+
+func newStaticResolver(baseURL string) URLResolver {
+	return &staticResolver{baseURL: baseURL}
+}

--- a/resolver.go
+++ b/resolver.go
@@ -1,5 +1,29 @@
 package api2go
 
+import "net/http"
+
+type callbackResolver struct {
+	callback func(r http.Request) string
+	r        http.Request
+}
+
+//NewCallbackResolver handles each resolve via
+//your provided callback func
+func NewCallbackResolver(callback func(http.Request) string) URLResolver {
+	return &callbackResolver{callback: callback}
+}
+
+//GetBaseURL calls the callback given in the constructor method
+//to implement `URLResolver`
+func (c callbackResolver) GetBaseURL() string {
+	return c.callback(c.r)
+}
+
+//SetRequest to implement `RequestAwareURLResolver`
+func (c *callbackResolver) SetRequest(r http.Request) {
+	c.r = r
+}
+
 //staticResolver is only used
 //for backwards compatible reasons
 //and might be removed in the future

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,0 +1,33 @@
+package api2go
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Resolver test", func() {
+	Context("basic function of callback resolver", func() {
+		It("works", func() {
+			callback := func(r http.Request) string {
+				if r.Header.Get("lol") != "" {
+					return "funny"
+				}
+
+				return "unfunny"
+			}
+
+			resolver := NewCallbackResolver(callback)
+			Expect(resolver.GetBaseURL()).To(Equal("unfunny"))
+			req, err := http.NewRequest("GET", "/v1/posts", nil)
+			req.Header.Set("lol", "lol")
+			Expect(err).To(BeNil())
+			requestResolver, ok := resolver.(RequestAwareURLResolver)
+			Expect(ok).To(Equal(true), "does not implement interface")
+			Expect(requestResolver.GetBaseURL()).To(Equal("unfunny"))
+			requestResolver.SetRequest(*req)
+			Expect(requestResolver.GetBaseURL()).To(Equal("funny"))
+		})
+	})
+})


### PR DESCRIPTION
this commit allows per request dynamic handling of baseUrls
it also deprecates the old NewAPIWithMarshalers in favor
of the new NewAPIWithMarshalling (name is subject to change).

It is fully backwards compatible.