### PR TITLE
[RFC] Extract router to be an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ go get github.com/manyminds/api2go/jsonapi
 - [Ignoring fields](#ignoring-fields)
 - [Manual marshaling / unmarshaling](#manual-marshaling--unmarshaling)
 - [SQL Null-Types](#sql-null-types)
+- [Using api2go with the gin framework](#api2go-with-gin)
 - [Building a REST API](#building-a-rest-api)
   - [Query Params](#query-params)
   - [Using Pagination](#using-pagination)
@@ -317,6 +318,47 @@ these values, it is required to implement the `json.Marshaller` and `json.Unmars
 
 But you dont have to do this by yourself! There already is a library that did the work for you. We recommend that you use the types
 of this library: http://gopkg.in/guregu/null.v2/zero
+
+## Using api2go with the gin framework
+
+If you want to use api2go with [gin](https://github.com/gin-gonic/gin) you need to use a different router than the default one.
+Get the according adapter using:
+
+```go get github.com/manyminds/api2go-adapter/gingonic```
+
+After that you can bootstrap api2go the following way:
+```go
+  import (
+    "github.com/gin-gonic/gin"
+    "github.com/manyminds/api2go"
+    "github.com/manyminds/api2go-adapter/gingonic"
+    "github.com/manyminds/api2go/examples/model"
+    "github.com/manyminds/api2go/examples/resource"
+    "github.com/manyminds/api2go/examples/storage"
+  )
+
+  func main() {
+    r := gin.Default()
+    api := api2go.NewAPIWithRouting(
+      "api",
+      api2go.NewStaticResolver("/"),
+      api2go.DefaultContentMarshalers,
+      gingonic.New(r),
+    )
+
+    userStorage := storage.NewUserStorage()
+    chocStorage := storage.NewChocolateStorage()
+    api.AddResource(model.User{}, resource.UserResource{ChocStorage: chocStorage, UserStorage: userStorage})
+    api.AddResource(model.Chocolate{}, resource.ChocolateResource{ChocStorage: chocStorage, UserStorage: userStorage})
+
+    r.GET("/ping", func(c *gin.Context) {
+      c.String(200, "pong")
+    })
+    r.Run(":8080")
+  }
+```
+
+Keep in mind that you absolutely should map api2go under its own namespace to not get conflicts with your normal routes.
 
 ## Building a REST API
 

--- a/api.go
+++ b/api.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 
 	"github.com/golang/gddo/httputil"
-	"github.com/julienschmidt/httprouter"
 	"github.com/manyminds/api2go/jsonapi"
+	"github.com/manyminds/api2go/routing"
 )
 
 const defaultContentTypHeader = "application/vnd.api+json"
@@ -191,6 +191,20 @@ type resource struct {
 	marshalers   map[string]ContentMarshaler
 }
 
+// AddResource registers a data source for the given resource
+// At least the CRUD interface must be implemented, all the other interfaces are optional.
+// `resource` should be either an empty struct instance such as `Post{}` or a pointer to
+// a struct such as `&Post{}`. The same type will be used for constructing new elements.
+func (api *API) AddResource(prototype jsonapi.MarshalIdentifier, source CRUD) {
+	api.addResource(prototype, source, api.marshalers)
+}
+
+// UseMiddleware registers middlewares that implement the api2go.HandlerFunc
+// Middleware is run before any generated routes.
+func (api *API) UseMiddleware(middleware ...HandlerFunc) {
+	api.middlewares = append(api.middlewares, middleware...)
+}
+
 // middlewareChain executes the middleeware chain setup
 func (api *API) middlewareChain(c APIContexter, w http.ResponseWriter, r *http.Request) {
 	for _, middleware := range api.middlewares {
@@ -235,11 +249,11 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		marshalers:   marshalers,
 	}
 
-	requestInfo := func(r *http.Request) *information {
+	requestInfo := func(r *http.Request, api *API) *information {
 		var info *information
 		if resolver, ok := api.info.resolver.(RequestAwareURLResolver); ok {
 			resolver.SetRequest(*r)
-			info = &information{prefix: api.prefix, resolver: resolver}
+			info = &information{prefix: api.info.prefix, resolver: resolver}
 		} else {
 			info = &api.info
 		}
@@ -247,7 +261,13 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		return info
 	}
 
-	api.router.Handle("OPTIONS", api.prefix+name, func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	prefix := strings.Trim(api.info.prefix, "/")
+	baseURL := "/" + name
+	if prefix != "" {
+		baseURL = "/" + prefix + baseURL
+	}
+
+	api.router.Handle("OPTIONS", baseURL, func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
@@ -256,7 +276,7 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		api.contextPool.Put(c)
 	})
 
-	api.router.Handle("OPTIONS", api.prefix+name+"/:id", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	api.router.Handle("OPTIONS", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
@@ -265,8 +285,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		api.contextPool.Put(c)
 	})
 
-	api.router.GET(api.prefix+name, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		info := requestInfo(r)
+	api.router.Handle("GET", baseURL, func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+		info := requestInfo(r, api)
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
@@ -278,12 +298,12 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		}
 	})
 
-	api.router.GET(api.prefix+name+"/:id", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		info := requestInfo(r)
+	api.router.Handle("GET", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		info := requestInfo(r, api)
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
-		err := res.handleRead(c, w, r, ps, *info)
+		err := res.handleRead(c, w, r, params, *info)
 		api.contextPool.Put(c)
 		if err != nil {
 			handleError(err, w, r, marshalers)
@@ -295,13 +315,13 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 	if ok {
 		relations := casted.GetReferences()
 		for _, relation := range relations {
-			api.router.GET(api.prefix+name+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) httprouter.Handle {
-				return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-					info := requestInfo(r)
+			api.router.Handle("GET", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+					info := requestInfo(r, api)
 					c := api.contextPool.Get().(APIContexter)
 					c.Reset()
 					api.middlewareChain(c, w, r)
-					err := res.handleReadRelation(c, w, r, ps, *info, relation)
+					err := res.handleReadRelation(c, w, r, params, *info, relation)
 					api.contextPool.Put(c)
 					if err != nil {
 						handleError(err, w, r, marshalers)
@@ -309,13 +329,13 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 				}
 			}(relation))
 
-			api.router.GET(api.prefix+name+"/:id/"+relation.Name, func(relation jsonapi.Reference) httprouter.Handle {
-				return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-					info := requestInfo(r)
+			api.router.Handle("GET", baseURL+"/:id/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+					info := requestInfo(r, api)
 					c := api.contextPool.Get().(APIContexter)
 					c.Reset()
 					api.middlewareChain(c, w, r)
-					err := res.handleLinked(c, api, w, r, ps, relation, *info)
+					err := res.handleLinked(c, api, w, r, params, relation, *info)
 					api.contextPool.Put(c)
 					if err != nil {
 						handleError(err, w, r, marshalers)
@@ -323,12 +343,12 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 				}
 			}(relation))
 
-			api.router.PATCH(api.prefix+name+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) httprouter.Handle {
-				return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+			api.router.Handle("PATCH", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 					c := api.contextPool.Get().(APIContexter)
 					c.Reset()
 					api.middlewareChain(c, w, r)
-					err := res.handleReplaceRelation(c, w, r, ps, relation)
+					err := res.handleReplaceRelation(c, w, r, params, relation)
 					api.contextPool.Put(c)
 					if err != nil {
 						handleError(err, w, r, marshalers)
@@ -338,12 +358,12 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 
 			if _, ok := ptrPrototype.(jsonapi.EditToManyRelations); ok && relation.Name == jsonapi.Pluralize(relation.Name) {
 				// generate additional routes to manipulate to-many relationships
-				api.router.POST(api.prefix+name+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) httprouter.Handle {
-					return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+				api.router.Handle("POST", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
+					return func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 						c := api.contextPool.Get().(APIContexter)
 						c.Reset()
 						api.middlewareChain(c, w, r)
-						err := res.handleAddToManyRelation(c, w, r, ps, relation)
+						err := res.handleAddToManyRelation(c, w, r, params, relation)
 						api.contextPool.Put(c)
 						if err != nil {
 							handleError(err, w, r, marshalers)
@@ -351,12 +371,12 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 					}
 				}(relation))
 
-				api.router.DELETE(api.prefix+name+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) httprouter.Handle {
-					return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+				api.router.Handle("DELETE", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
+					return func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 						c := api.contextPool.Get().(APIContexter)
 						c.Reset()
 						api.middlewareChain(c, w, r)
-						err := res.handleDeleteToManyRelation(c, w, r, ps, relation)
+						err := res.handleDeleteToManyRelation(c, w, r, params, relation)
 						api.contextPool.Put(c)
 						if err != nil {
 							handleError(err, w, r, marshalers)
@@ -367,34 +387,34 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD, ma
 		}
 	}
 
-	api.router.POST(api.prefix+name, func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		info := requestInfo(r)
+	api.router.Handle("POST", baseURL, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		info := requestInfo(r, api)
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
-		err := res.handleCreate(c, w, r, api.prefix, *info)
+		err := res.handleCreate(c, w, r, info.prefix, *info)
 		api.contextPool.Put(c)
 		if err != nil {
 			handleError(err, w, r, marshalers)
 		}
 	})
 
-	api.router.DELETE(api.prefix+name+"/:id", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	api.router.Handle("DELETE", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
-		err := res.handleDelete(c, w, r, ps)
+		err := res.handleDelete(c, w, r, params)
 		api.contextPool.Put(c)
 		if err != nil {
 			handleError(err, w, r, marshalers)
 		}
 	})
 
-	api.router.PATCH(api.prefix+name+"/:id", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	api.router.Handle("PATCH", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 		c := api.contextPool.Get().(APIContexter)
 		c.Reset()
 		api.middlewareChain(c, w, r)
-		err := res.handleUpdate(c, w, r, ps)
+		err := res.handleUpdate(c, w, r, params)
 		api.contextPool.Put(c)
 		if err != nil {
 			handleError(err, w, r, marshalers)
@@ -451,8 +471,8 @@ func (res *resource) handleIndex(c APIContexter, w http.ResponseWriter, r *http.
 	return respondWith(response, info, http.StatusOK, w, r, res.marshalers)
 }
 
-func (res *resource) handleRead(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params, info information) error {
-	id := ps.ByName("id")
+func (res *resource) handleRead(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string, info information) error {
+	id := params["id"]
 
 	response, err := res.source.FindOne(id, buildRequest(c, r))
 
@@ -463,8 +483,8 @@ func (res *resource) handleRead(c APIContexter, w http.ResponseWriter, r *http.R
 	return respondWith(response, info, http.StatusOK, w, r, res.marshalers)
 }
 
-func (res *resource) handleReadRelation(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params, info information, relation jsonapi.Reference) error {
-	id := ps.ByName("id")
+func (res *resource) handleReadRelation(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string, info information, relation jsonapi.Reference) error {
+	id := params["id"]
 
 	obj, err := res.source.FindOne(id, buildRequest(c, r))
 	if err != nil {
@@ -519,8 +539,8 @@ func (res *resource) handleReadRelation(c APIContexter, w http.ResponseWriter, r
 }
 
 // try to find the referenced resource and call the findAll Method with referencing resource id as param
-func (res *resource) handleLinked(c APIContexter, api *API, w http.ResponseWriter, r *http.Request, ps httprouter.Params, linked jsonapi.Reference, info information) error {
-	id := ps.ByName("id")
+func (res *resource) handleLinked(c APIContexter, api *API, w http.ResponseWriter, r *http.Request, params map[string]string, linked jsonapi.Reference, info information) error {
+	id := params["id"]
 	for _, resource := range api.resources {
 		if resource.name == linked.Type {
 			request := buildRequest(c, r)
@@ -607,7 +627,8 @@ func (res *resource) handleCreate(c APIContexter, w http.ResponseWriter, r *http
 	if !ok {
 		return fmt.Errorf("Expected one newly created object by resource %s", res.name)
 	}
-	w.Header().Set("Location", prefix+res.name+"/"+result.GetID())
+
+	w.Header().Set("Location", "/"+prefix+"/"+res.name+"/"+result.GetID())
 
 	// handle 200 status codes
 	switch response.StatusCode() {
@@ -624,8 +645,9 @@ func (res *resource) handleCreate(c APIContexter, w http.ResponseWriter, r *http
 	}
 }
 
-func (res *resource) handleUpdate(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params) error {
-	obj, err := res.source.FindOne(ps.ByName("id"), buildRequest(c, r))
+func (res *resource) handleUpdate(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string) error {
+	id := params["id"]
+	obj, err := res.source.FindOne(id, buildRequest(c, r))
 	if err != nil {
 		return err
 	}
@@ -698,7 +720,7 @@ func (res *resource) handleUpdate(c APIContexter, w http.ResponseWriter, r *http
 	case http.StatusOK:
 		updated := response.Result()
 		if updated == nil {
-			internalResponse, err := res.source.FindOne(ps.ByName("id"), buildRequest(c, r))
+			internalResponse, err := res.source.FindOne(id, buildRequest(c, r))
 			if err != nil {
 				return err
 			}
@@ -722,13 +744,15 @@ func (res *resource) handleUpdate(c APIContexter, w http.ResponseWriter, r *http
 	}
 }
 
-func (res *resource) handleReplaceRelation(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params, relation jsonapi.Reference) error {
+func (res *resource) handleReplaceRelation(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string, relation jsonapi.Reference) error {
 	var (
 		err     error
 		editObj interface{}
 	)
 
-	response, err := res.source.FindOne(ps.ByName("id"), buildRequest(c, r))
+	id := params["id"]
+
+	response, err := res.source.FindOne(id, buildRequest(c, r))
 	if err != nil {
 		return err
 	}
@@ -765,13 +789,15 @@ func (res *resource) handleReplaceRelation(c APIContexter, w http.ResponseWriter
 	return err
 }
 
-func (res *resource) handleAddToManyRelation(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params, relation jsonapi.Reference) error {
+func (res *resource) handleAddToManyRelation(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string, relation jsonapi.Reference) error {
 	var (
 		err     error
 		editObj interface{}
 	)
 
-	response, err := res.source.FindOne(ps.ByName("id"), buildRequest(c, r))
+	id := params["id"]
+
+	response, err := res.source.FindOne(id, buildRequest(c, r))
 	if err != nil {
 		return err
 	}
@@ -830,12 +856,15 @@ func (res *resource) handleAddToManyRelation(c APIContexter, w http.ResponseWrit
 	return err
 }
 
-func (res *resource) handleDeleteToManyRelation(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params, relation jsonapi.Reference) error {
+func (res *resource) handleDeleteToManyRelation(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string, relation jsonapi.Reference) error {
 	var (
 		err     error
 		editObj interface{}
 	)
-	response, err := res.source.FindOne(ps.ByName("id"), buildRequest(c, r))
+
+	id := params["id"]
+
+	response, err := res.source.FindOne(id, buildRequest(c, r))
 	if err != nil {
 		return err
 	}
@@ -902,8 +931,9 @@ func getPointerToStruct(oldObj interface{}) interface{} {
 	return ptr.Interface()
 }
 
-func (res *resource) handleDelete(c APIContexter, w http.ResponseWriter, r *http.Request, ps httprouter.Params) error {
-	response, err := res.source.Delete(ps.ByName("id"), buildRequest(c, r))
+func (res *resource) handleDelete(c APIContexter, w http.ResponseWriter, r *http.Request, params map[string]string) error {
+	id := params["id"]
+	response, err := res.source.Delete(id, buildRequest(c, r))
 	if err != nil {
 		return err
 	}

--- a/api.go
+++ b/api.go
@@ -191,20 +191,6 @@ type resource struct {
 	marshalers   map[string]ContentMarshaler
 }
 
-// AddResource registers a data source for the given resource
-// At least the CRUD interface must be implemented, all the other interfaces are optional.
-// `resource` should be either an empty struct instance such as `Post{}` or a pointer to
-// a struct such as `&Post{}`. The same type will be used for constructing new elements.
-func (api *API) AddResource(prototype jsonapi.MarshalIdentifier, source CRUD) {
-	api.addResource(prototype, source, api.marshalers)
-}
-
-// UseMiddleware registers middlewares that implement the api2go.HandlerFunc
-// Middleware is run before any generated routes.
-func (api *API) UseMiddleware(middleware ...HandlerFunc) {
-	api.middlewares = append(api.middlewares, middleware...)
-}
-
 // middlewareChain executes the middleeware chain setup
 func (api *API) middlewareChain(c APIContexter, w http.ResponseWriter, r *http.Request) {
 	for _, middleware := range api.middlewares {

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -63,17 +63,17 @@ type URLResolver interface {
 	GetBaseURL() string
 }
 
-//RequestAwareURLResolver allows you to dynamically change
-//generated urls.
+// RequestAwareURLResolver allows you to dynamically change
+// generated urls.
 //
-//This is particulary useful if you have the same
-//API answering to multiple domains, or subdomains
-//e.g customer[1,2,3,4].yourapi.example.com
+// This is particulary useful if you have the same
+// API answering to multiple domains, or subdomains
+// e.g customer[1,2,3,4].yourapi.example.com
 //
-//SetRequest will always be called prior to
-//the GetBaseURL() from `URLResolver` so you
-//have to change the result value based on the last
-//request.
+// SetRequest will always be called prior to
+// the GetBaseURL() from `URLResolver` so you
+// have to change the result value based on the last
+// request.
 type RequestAwareURLResolver interface {
 	URLResolver
 	SetRequest(http.Request)

--- a/api_public.go
+++ b/api_public.go
@@ -1,23 +1,26 @@
 package api2go
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 	"sync"
 
-	"github.com/julienschmidt/httprouter"
-	"github.com/manyminds/api2go/jsonapi"
+	"github.com/manyminds/api2go/routing"
 )
 
 // HandlerFunc for api2go middlewares
 type HandlerFunc func(APIContexter, http.ResponseWriter, *http.Request)
 
+// DefaultContentMarshalers is the default set of content marshalers for an API.
+// Currently this means handling application/vnd.api+json content type bodies
+// using the standard encoding/json package.
+var DefaultContentMarshalers = map[string]ContentMarshaler{
+	defaultContentTypHeader: JSONContentMarshaler{},
+}
+
 // API is a REST JSONAPI.
 type API struct {
-	router *httprouter.Router
-	// Route prefix, including slashes
-	prefix           string
+	router           routing.Routeable
 	info             information
 	resources        []resource
 	marshalers       map[string]ContentMarshaler
@@ -27,27 +30,13 @@ type API struct {
 }
 
 // Handler returns the http.Handler instance for the API.
-func (api *API) Handler() http.Handler {
+func (api API) Handler() http.Handler {
+	return api.router.Handler()
+}
+
+//Router returns the specified router on an api instance
+func (api API) Router() routing.Routeable {
 	return api.router
-}
-
-// Router can be used instead of Handler() to get the instance of julienschmidt httprouter.
-func (api *API) Router() *httprouter.Router {
-	return api.router
-}
-
-// AddResource registers a data source for the given resource
-// At least the CRUD interface must be implemented, all the other interfaces are optional.
-// `resource` should be either an empty struct instance such as `Post{}` or a pointer to
-// a struct such as `&Post{}`. The same type will be used for constructing new elements.
-func (api *API) AddResource(prototype jsonapi.MarshalIdentifier, source CRUD) {
-	api.addResource(prototype, source, api.marshalers)
-}
-
-// UseMiddleware registers middlewares that implement the api2go.HandlerFunc
-// Middleware is run before any generated routes.
-func (api *API) UseMiddleware(middleware ...HandlerFunc) {
-	api.middlewares = append(api.middlewares, middleware...)
 }
 
 // SetContextAllocator custom implementation for making contexts
@@ -55,29 +44,21 @@ func (api *API) SetContextAllocator(allocator APIContextAllocatorFunc) {
 	api.contextAllocator = allocator
 }
 
-// Request contains additional information for FindOne and Find Requests
-type Request struct {
-	PlainRequest *http.Request
-	QueryParams  map[string][]string
-	Header       http.Header
-	Context      APIContexter
-}
-
 //SetRedirectTrailingSlash enables 307 redirects on urls ending with /
 //when disabled, an URL ending with / will 404
+//this will and should work only if using the default router
+//DEPRECATED
 func (api *API) SetRedirectTrailingSlash(enabled bool) {
 	if api.router == nil {
 		panic("router must not be nil")
 	}
 
-	api.router.RedirectTrailingSlash = enabled
-}
+	httpRouter, ok := api.router.(*routing.HTTPRouter)
+	if !ok {
+		panic("can not set redirectTrailingSlashes if not using the internal httpRouter")
+	}
 
-//NewAPIWithMarshalers is DEPRECATED
-//use NewApiWithMarshalling instead
-func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]ContentMarshaler) *API {
-	staticResolver := newStaticResolver(baseURL)
-	return NewAPIWithMarshalling(prefix, staticResolver, marshalers)
+	httpRouter.SetRedirectTrailingSlash(enabled)
 }
 
 // NewAPIWithMarshalling does the same as NewAPIWithBaseURL with the addition
@@ -88,6 +69,39 @@ func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]C
 // preferred content type, otherwise it will respond using whatever content
 // type the client provided in its Content-Type request header.
 func NewAPIWithMarshalling(prefix string, resolver URLResolver, marshalers map[string]ContentMarshaler) *API {
+	r := routing.NewHTTPRouter(prefix, notAllowedHandler{marshalers: marshalers})
+	return newAPI(prefix, resolver, marshalers, r)
+}
+
+// NewAPIWithBaseURL does the same as NewAPI with the addition of
+// a baseURL which get's added in front of all generated URLs.
+// For example http://localhost/v1/myResource/abc instead of /v1/myResource/abc
+func NewAPIWithBaseURL(prefix string, baseURL string) *API {
+	return NewAPIWithMarshalers(prefix, baseURL, DefaultContentMarshalers)
+}
+
+// NewAPI returns an initialized API instance
+// `prefix` is added in front of all endpoints.
+func NewAPI(prefix string) *API {
+	return NewAPIWithMarshalers(prefix, "", DefaultContentMarshalers)
+}
+
+//NewAPIWithRouting allows you to use a custom URLResolver, marshalers and custom routing
+//if you want to use the default routing, you should use another constructor.
+//
+//If you don't need any of the parameters you can skip them with the defaults:
+//the default for `prefix` would be `""`, which means there is no namespace for your api.
+//although we suggest using one.
+//
+//if your api only answers to one url you can use a NewStaticResolver() as  `resolver`
+//
+//if you have no specific marshalling needs, use `DefaultContentMarshalers`
+func NewAPIWithRouting(prefix string, resolver URLResolver, marshalers map[string]ContentMarshaler, router routing.Routeable) *API {
+	return newAPI(prefix, resolver, marshalers, router)
+}
+
+//newAPI is now an internal method that can be changed if params are changing
+func newAPI(prefix string, resolver URLResolver, marshalers map[string]ContentMarshaler, router routing.Routeable) *API {
 	if len(marshalers) == 0 {
 		panic("marshaler map must not be empty")
 	}
@@ -100,14 +114,10 @@ func NewAPIWithMarshalling(prefix string, resolver URLResolver, marshalers map[s
 		prefixSlashes = "/"
 	}
 
-	router := httprouter.New()
-	router.MethodNotAllowed = notAllowedHandler{marshalers: marshalers}
-
 	info := information{prefix: prefix, resolver: resolver}
 
 	api := &API{
 		router:           router,
-		prefix:           prefixSlashes,
 		info:             info,
 		marshalers:       marshalers,
 		middlewares:      make([]HandlerFunc, 0),
@@ -124,62 +134,9 @@ func NewAPIWithMarshalling(prefix string, resolver URLResolver, marshalers map[s
 	return api
 }
 
-// NewAPI returns an initialized API instance
-// `prefix` is added in front of all endpoints.
-func NewAPI(prefix string) *API {
-	return NewAPIWithMarshalers(prefix, "", DefaultContentMarshalers)
-}
-
-// NewAPIWithBaseURL does the same as NewAPI with the addition of
-// a baseURL which get's added in front of all generated URLs.
-// For example http://localhost/v1/myResource/abc instead of /v1/myResource/abc
-func NewAPIWithBaseURL(prefix string, baseURL string) *API {
-	return NewAPIWithMarshalers(prefix, baseURL, DefaultContentMarshalers)
-}
-
-// DefaultContentMarshalers is the default set of content marshalers for an API.
-// Currently this means handling application/vnd.api+json content type bodies
-// using the standard encoding/json package.
-var DefaultContentMarshalers = map[string]ContentMarshaler{
-	defaultContentTypHeader: JSONContentMarshaler{},
-}
-
-// JSONContentMarshaler uses the standard encoding/json package for
-// decoding requests and encoding responses in JSON format.
-type JSONContentMarshaler struct {
-}
-
-// Marshal marshals with default JSON
-func (m JSONContentMarshaler) Marshal(i interface{}) ([]byte, error) {
-	return json.Marshal(i)
-}
-
-// Unmarshal with default JSON
-func (m JSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
-	return json.Unmarshal(data, i)
-}
-
-//The Response struct implements api2go.Responder and can be used as a default
-//implementation for your responses
-//you can fill the field `Meta` with all the metadata your application needs
-//like license, tokens, etc
-type Response struct {
-	Res  interface{}
-	Code int
-	Meta map[string]interface{}
-}
-
-// Metadata returns additional meta data
-func (r Response) Metadata() map[string]interface{} {
-	return r.Meta
-}
-
-// Result returns the actual payload
-func (r Response) Result() interface{} {
-	return r.Res
-}
-
-// StatusCode sets the return status code
-func (r Response) StatusCode() int {
-	return r.Code
+//NewAPIWithMarshalers is DEPRECATED
+//use NewApiWithMarshalling instead
+func NewAPIWithMarshalers(prefix string, baseURL string, marshalers map[string]ContentMarshaler) *API {
+	staticResolver := NewStaticResolver(baseURL)
+	return NewAPIWithMarshalling(prefix, staticResolver, marshalers)
 }

--- a/content_marshaler.go
+++ b/content_marshaler.go
@@ -1,0 +1,18 @@
+package api2go
+
+import "encoding/json"
+
+// JSONContentMarshaler uses the standard encoding/json package for
+// decoding requests and encoding responses in JSON format.
+type JSONContentMarshaler struct {
+}
+
+// Marshal marshals with default JSON
+func (m JSONContentMarshaler) Marshal(i interface{}) ([]byte, error) {
+	return json.Marshal(i)
+}
+
+// Unmarshal with default JSON
+func (m JSONContentMarshaler) Unmarshal(data []byte, i interface{}) error {
+	return json.Unmarshal(data, i)
+}

--- a/error.go
+++ b/error.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-//HTTPError is used for errors
+// HTTPError is used for errors
 type HTTPError struct {
 	err    error
 	msg    string
@@ -14,10 +14,10 @@ type HTTPError struct {
 	Errors []Error `json:"errors,omitempty"`
 }
 
-//Error can be used for all kind of application errors
-//e.g. you would use it to define form errors or any
-//other semantical application problems
-//for more information see http://jsonapi.org/format/#errors
+// Error can be used for all kind of application errors
+// e.g. you would use it to define form errors or any
+// other semantical application problems
+// for more information see http://jsonapi.org/format/#errors
 type Error struct {
 	ID     string       `json:"id,omitempty"`
 	Links  *ErrorLinks  `json:"links,omitempty"`
@@ -34,28 +34,28 @@ func (e Error) GetID() string {
 	return e.ID
 }
 
-//ErrorLinks is used to provide an About URL that leads to
-//further details about the particular occurrence of the problem.
+// ErrorLinks is used to provide an About URL that leads to
+// further details about the particular occurrence of the problem.
 //
-//for more information see http://jsonapi.org/format/#error-objects
+// for more information see http://jsonapi.org/format/#error-objects
 type ErrorLinks struct {
 	About string `json:"about,omitempty"`
 }
 
-//ErrorSource is used to provide references to the source of an error.
+// ErrorSource is used to provide references to the source of an error.
 //
-//The Pointer is a JSON Pointer to the associated entity in the request
-//document.
-//The Paramter is a string indicating which query parameter caused the error.
+// The Pointer is a JSON Pointer to the associated entity in the request
+// document.
+// The Paramter is a string indicating which query parameter caused the error.
 //
-//for more information see http://jsonapi.org/format/#error-objects
+// for more information see http://jsonapi.org/format/#error-objects
 type ErrorSource struct {
 	Pointer   string `json:"pointer,omitempty"`
 	Parameter string `json:"parameter,omitempty"`
 }
 
-//MarshalError marshals errors recursively in json format.
-//it can make use of the jsonapi.HTTPError struct
+// MarshalError marshals errors recursively in json format.
+// it can make use of the jsonapi.HTTPError struct
 func (j JSONContentMarshaler) MarshalError(err error) string {
 	httpErr, ok := err.(HTTPError)
 	if ok {
@@ -67,7 +67,7 @@ func (j JSONContentMarshaler) MarshalError(err error) string {
 	return marshalHTTPError(httpErr, j)
 }
 
-//marshalHTTPError marshals an internal httpError
+// marshalHTTPError marshals an internal httpError
 func marshalHTTPError(input HTTPError, marshaler ContentMarshaler) string {
 	if len(input.Errors) == 0 {
 		input.Errors = []Error{{Title: input.msg, Status: strconv.Itoa(input.status)}}
@@ -90,7 +90,7 @@ func NewHTTPError(err error, msg string, status int) HTTPError {
 	return HTTPError{err: err, msg: msg, status: status}
 }
 
-//Error returns a nice string represenation including the status
+// Error returns a nice string represenation including the status
 func (e HTTPError) Error() string {
 	msg := fmt.Sprintf("http error (%d) %s and %d more errors", e.status, e.msg, len(e.Errors))
 	if e.err != nil {

--- a/examples/resource/resource_user.go
+++ b/examples/resource/resource_user.go
@@ -119,7 +119,7 @@ func (s UserResource) PaginatedFindAll(r api2go.Request) (uint, api2go.Responder
 func (s UserResource) FindOne(ID string, r api2go.Request) (api2go.Responder, error) {
 	user, err := s.UserStorage.GetOne(ID)
 	if err != nil {
-		return &Response{}, err
+		return &Response{}, api2go.NewHTTPError(err, err.Error(), http.StatusNotFound)
 	}
 
 	user.Chocolates = []*model.Chocolate{}

--- a/request.go
+++ b/request.go
@@ -1,0 +1,11 @@
+package api2go
+
+import "net/http"
+
+// Request contains additional information for FindOne and Find Requests
+type Request struct {
+	PlainRequest *http.Request
+	QueryParams  map[string][]string
+	Header       http.Header
+	Context      APIContexter
+}

--- a/resolver.go
+++ b/resolver.go
@@ -7,26 +7,26 @@ type callbackResolver struct {
 	r        http.Request
 }
 
-//NewCallbackResolver handles each resolve via
-//your provided callback func
+// NewCallbackResolver handles each resolve via
+// your provided callback func
 func NewCallbackResolver(callback func(http.Request) string) URLResolver {
 	return &callbackResolver{callback: callback}
 }
 
-//GetBaseURL calls the callback given in the constructor method
-//to implement `URLResolver`
+// GetBaseURL calls the callback given in the constructor method
+// to implement `URLResolver`
 func (c callbackResolver) GetBaseURL() string {
 	return c.callback(c.r)
 }
 
-//SetRequest to implement `RequestAwareURLResolver`
+// SetRequest to implement `RequestAwareURLResolver`
 func (c *callbackResolver) SetRequest(r http.Request) {
 	c.r = r
 }
 
-//staticResolver is only used
-//for backwards compatible reasons
-//and might be removed in the future
+// staticResolver is only used
+// for backwards compatible reasons
+// and might be removed in the future
 type staticResolver struct {
 	baseURL string
 }
@@ -35,8 +35,8 @@ func (s staticResolver) GetBaseURL() string {
 	return s.baseURL
 }
 
-//NewStaticResolver returns a simple resolver that
-//will always answer with the same url
+// NewStaticResolver returns a simple resolver that
+// will always answer with the same url
 func NewStaticResolver(baseURL string) URLResolver {
 	return &staticResolver{baseURL: baseURL}
 }

--- a/resolver.go
+++ b/resolver.go
@@ -35,6 +35,8 @@ func (s staticResolver) GetBaseURL() string {
 	return s.baseURL
 }
 
-func newStaticResolver(baseURL string) URLResolver {
+//NewStaticResolver returns a simple resolver that
+//will always answer with the same url
+func NewStaticResolver(baseURL string) URLResolver {
 	return &staticResolver{baseURL: baseURL}
 }

--- a/response.go
+++ b/response.go
@@ -1,0 +1,26 @@
+package api2go
+
+//The Response struct implements api2go.Responder and can be used as a default
+//implementation for your responses
+//you can fill the field `Meta` with all the metadata your application needs
+//like license, tokens, etc
+type Response struct {
+	Res  interface{}
+	Code int
+	Meta map[string]interface{}
+}
+
+// Metadata returns additional meta data
+func (r Response) Metadata() map[string]interface{} {
+	return r.Meta
+}
+
+// Result returns the actual payload
+func (r Response) Result() interface{} {
+	return r.Res
+}
+
+// StatusCode sets the return status code
+func (r Response) StatusCode() int {
+	return r.Code
+}

--- a/response.go
+++ b/response.go
@@ -1,9 +1,9 @@
 package api2go
 
-//The Response struct implements api2go.Responder and can be used as a default
-//implementation for your responses
-//you can fill the field `Meta` with all the metadata your application needs
-//like license, tokens, etc
+// The Response struct implements api2go.Responder and can be used as a default
+// implementation for your responses
+// you can fill the field `Meta` with all the metadata your application needs
+// like license, tokens, etc
 type Response struct {
 	Res  interface{}
 	Code int

--- a/routing/httprouter.go
+++ b/routing/httprouter.go
@@ -6,12 +6,12 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-//HTTPRouter default router implementation for api2go
+// HTTPRouter default router implementation for api2go
 type HTTPRouter struct {
 	router *httprouter.Router
 }
 
-//Handle each method like before and wrap them into julienschmidt handler func style
+// Handle each method like before and wrap them into julienschmidt handler func style
 func (h HTTPRouter) Handle(protocol, route string, handler HandlerFunc) {
 	wrappedCallback := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		params := map[string]string{}
@@ -25,26 +25,26 @@ func (h HTTPRouter) Handle(protocol, route string, handler HandlerFunc) {
 	h.router.Handle(protocol, route, wrappedCallback)
 }
 
-//Handler returns the router
+// Handler returns the router
 func (h HTTPRouter) Handler() http.Handler {
 	return h.router
 }
 
-//SetRedirectTrailingSlash wraps this internal functionality of
-//the julienschmidt router.
+// SetRedirectTrailingSlash wraps this internal functionality of
+// the julienschmidt router.
 func (h HTTPRouter) SetRedirectTrailingSlash(enabled bool) {
 	h.router.RedirectTrailingSlash = enabled
 }
 
-//GetRouteParameter implemention will extract the param the julienschmidt way
+// GetRouteParameter implemention will extract the param the julienschmidt way
 func (h HTTPRouter) GetRouteParameter(r http.Request, param string) string {
 	path := httprouter.CleanPath(r.URL.Path)
 	_, params, _ := h.router.Lookup(r.Method, path)
 	return params.ByName(param)
 }
 
-//NewHTTPRouter returns a new instance of julienschmidt/httprouter
-//this is the default router when using api2go
+// NewHTTPRouter returns a new instance of julienschmidt/httprouter
+// this is the default router when using api2go
 func NewHTTPRouter(prefix string, notAllowedHandler http.Handler) Routeable {
 	router := httprouter.New()
 	router.HandleMethodNotAllowed = true

--- a/routing/httprouter.go
+++ b/routing/httprouter.go
@@ -1,0 +1,53 @@
+package routing
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+//HTTPRouter default router implementation for api2go
+type HTTPRouter struct {
+	router *httprouter.Router
+}
+
+//Handle each method like before and wrap them into julienschmidt handler func style
+func (h HTTPRouter) Handle(protocol, route string, handler HandlerFunc) {
+	wrappedCallback := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		params := map[string]string{}
+		for _, p := range ps {
+			params[p.Key] = p.Value
+		}
+
+		handler(w, r, params)
+	}
+
+	h.router.Handle(protocol, route, wrappedCallback)
+}
+
+//Handler returns the router
+func (h HTTPRouter) Handler() http.Handler {
+	return h.router
+}
+
+//SetRedirectTrailingSlash wraps this internal functionality of
+//the julienschmidt router.
+func (h HTTPRouter) SetRedirectTrailingSlash(enabled bool) {
+	h.router.RedirectTrailingSlash = enabled
+}
+
+//GetRouteParameter implemention will extract the param the julienschmidt way
+func (h HTTPRouter) GetRouteParameter(r http.Request, param string) string {
+	path := httprouter.CleanPath(r.URL.Path)
+	_, params, _ := h.router.Lookup(r.Method, path)
+	return params.ByName(param)
+}
+
+//NewHTTPRouter returns a new instance of julienschmidt/httprouter
+//this is the default router when using api2go
+func NewHTTPRouter(prefix string, notAllowedHandler http.Handler) Routeable {
+	router := httprouter.New()
+	router.HandleMethodNotAllowed = true
+	router.MethodNotAllowed = notAllowedHandler
+	return &HTTPRouter{router: router}
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -1,0 +1,22 @@
+package routing
+
+import "net/http"
+
+//HandlerFunc must contain all params from the route
+//in the form key,value
+type HandlerFunc func(w http.ResponseWriter, r *http.Request, params map[string]string)
+
+//Routeable allows drop in replacement for api2go's router
+//by default, we are using julienschmidt/httprouter
+//but you can use any router that has similiar features
+//e.g. gin
+type Routeable interface {
+	//Handler should return the routers main handler, often this is the router itself
+	Handler() http.Handler
+	//Handle must be implemented to register api2go's default routines
+	//to your used router.
+	//protocol will be PATCH,OPTIONS,GET,POST,PUT
+	//route will be the request route /items/:id where :id means dynamically filled params
+	//handler is the handler that will answer to this specific route
+	Handle(protocol, route string, handler HandlerFunc)
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -2,21 +2,21 @@ package routing
 
 import "net/http"
 
-//HandlerFunc must contain all params from the route
-//in the form key,value
+// HandlerFunc must contain all params from the route
+// in the form key,value
 type HandlerFunc func(w http.ResponseWriter, r *http.Request, params map[string]string)
 
-//Routeable allows drop in replacement for api2go's router
-//by default, we are using julienschmidt/httprouter
-//but you can use any router that has similiar features
-//e.g. gin
+// Routeable allows drop in replacement for api2go's router
+// by default, we are using julienschmidt/httprouter
+// but you can use any router that has similiar features
+// e.g. gin
 type Routeable interface {
-	//Handler should return the routers main handler, often this is the router itself
+	// Handler should return the routers main handler, often this is the router itself
 	Handler() http.Handler
-	//Handle must be implemented to register api2go's default routines
-	//to your used router.
-	//protocol will be PATCH,OPTIONS,GET,POST,PUT
-	//route will be the request route /items/:id where :id means dynamically filled params
-	//handler is the handler that will answer to this specific route
+	// Handle must be implemented to register api2go's default routines
+	// to your used router.
+	// protocol will be PATCH,OPTIONS,GET,POST,PUT
+	// route will be the request route /items/:id where :id means dynamically filled params
+	// handler is the handler that will answer to this specific route
 	Handle(protocol, route string, handler HandlerFunc)
 }


### PR DESCRIPTION
this is particulary useful since more and more people
are trying to use api2go with gin router.

Since we have built so many new features I will restructure our constructors within this pr.
This will probably deprecate every constructor so far except the simple `NewAPI(namespace string)` one.