### PR TITLE
fix too early return when unmarshal embedded structs

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -356,12 +356,12 @@ func (s *SQLNullPost) SetID(ID string) error {
 }
 
 type RenamedPostWithEmbedding struct {
+	Embedded SQLNullPost
 	ID       string `jsonapi:"-"`
 	Another  string `jsonapi:"name=another"`
 	Field    string `jsonapi:"name=foo"`
 	Other    string `jsonapi:"name=bar-bar"`
 	Ignored  string `jsonapi:"-"`
-	Embedded SQLNullPost
 }
 
 func (p *RenamedPostWithEmbedding) SetID(ID string) error {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -320,7 +320,9 @@ func getFieldByTagName(val reflect.Value, fieldName string) (field reflect.Value
 			_, isEmbedded := val.Field(x).Addr().Interface().(UnmarshalIdentifier)
 			if isEmbedded {
 				field, found = getFieldByTagName(val.Field(x), fieldName)
-				return
+				if found {
+					return
+				}
 			}
 		}
 

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -315,6 +315,11 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 // check if there is any field tag with the given name available
 func getFieldByTagName(val reflect.Value, fieldName string) (field reflect.Value, found bool) {
 	for x := 0; x < val.NumField(); x++ {
+		tfield := val.Type().Field(x)
+		if tfield.Tag.Get("jsonapi") == "-" {
+			continue
+		}
+
 		// check if there is an embedded struct which needs to be searched
 		if val.Field(x).CanAddr() && val.Field(x).Addr().CanInterface() {
 			_, isEmbedded := val.Field(x).Addr().Interface().(UnmarshalIdentifier)
@@ -327,9 +332,8 @@ func getFieldByTagName(val reflect.Value, fieldName string) (field reflect.Value
 		}
 
 		// try to find the field
-		tfield := val.Type().Field(x)
 		name := GetTagValueByName(tfield, "name")
-		if tfield.Tag.Get("jsonapi") != "-" && strings.ToLower(name) == strings.ToLower(fieldName) {
+		if strings.ToLower(name) == strings.ToLower(fieldName) {
 			field = val.Field(x)
 			found = true
 			return


### PR DESCRIPTION
the search needs to go on if the field from the json was not found in the embedded struct and there are other fields. Now there is a check for that.

I changed the struct for the test, that triggered the error too. So we got that covered now.

This resolves #199 