### PR TITLE
Cleaner error message by renamed unexported fields

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -72,6 +72,7 @@ type SimplePost struct {
 	Size        int
 	Created     time.Time `jsonapi:"name=create-date"`
 	Updated     time.Time `jsonapi:"name=updated-date"`
+	topSecret   string    `jsonapi:"name=top-secret"`
 }
 
 func (s SimplePost) GetID() string {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -260,6 +260,7 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 						//check if there is any field tag with the given name available
 						field, found = getFieldByTagName(val, fieldName)
 					}
+
 					if !found || fieldType.Tag.Get("jsonapi") == "-" {
 						return fmt.Errorf("invalid key \"%s\" in json. Cannot be assigned to target struct \"%s\"", key, targetStructType.Name())
 					}
@@ -267,6 +268,10 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 					value := reflect.ValueOf(attributeValue)
 
 					if value.IsValid() {
+						if !field.CanInterface() {
+							return fmt.Errorf("field not exported. Expected field with name %s to exist", fieldName)
+						}
+
 						plainValue := reflect.ValueOf(attributeValue)
 
 						switch field.Interface().(type) {

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -58,12 +58,30 @@ var _ = Describe("Unmarshal", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(posts).To(Equal([]SimplePost{firstPost}))
 		})
-
 		It("unmarshals single objects into a struct", func() {
 			var post SimplePost
 			err := Unmarshal(singlePostMap, &post)
 			Expect(err).To(BeNil())
 			Expect(post).To(Equal(firstPost))
+		})
+
+		It("does not unmarshal private fields", func() {
+			failingPostMap := map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":   "1",
+					"type": "simplePosts",
+					"attributes": map[string]interface{}{
+						"title":       firstPost.Title,
+						"text":        firstPost.Text,
+						"create-date": "2014-11-10T16:30:48.823Z",
+						"top-secret":  "fish",
+					},
+				},
+			}
+			var post SimplePost
+			err := Unmarshal(failingPostMap, &post)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("field not exported. Expected field with name Top-secret to exist"))
 		})
 
 		It("unmarshals multiple objects", func() {


### PR DESCRIPTION
The only way to check this that I could find was to use
recover.

If anyone has an idea how to check if a field is private beforehand I would
appreciate it deeply. :/