### PR TITLE
fall back to json tag for name on fields

### DIFF
--- a/jsonapi/helpers.go
+++ b/jsonapi/helpers.go
@@ -86,7 +86,16 @@ func Singularize(word string) string {
 func GetTagValueByName(tfield reflect.StructField, name string) string {
 	str := tfield.Tag.Get("jsonapi")
 	if str == "" {
-		return ""
+		str = tfield.Tag.Get("json")
+		if str == "" || str == "-" {
+			return ""
+		}
+
+		if idx := strings.Index(str, ","); idx != -1 {
+			return str[:idx]
+		}
+		return str
+
 	}
 
 	tags := strings.Split(str, ";")

--- a/jsonapi/helpers_test.go
+++ b/jsonapi/helpers_test.go
@@ -38,7 +38,9 @@ var _ = Describe("StringHelpers", func() {
 
 	Context("Reflect funcs", func() {
 		type Element struct {
-			Name string `jsonapi:"name=actress;body=hot;chest=awesome;character"`
+			Name         string `jsonapi:"name=actress;body=hot;chest=awesome;character"`
+			FavoriteFood string `json:"favorite_food",jsonapi:""`
+			Color        string `json:"-"`
 		}
 
 		It("tests for existance of settings", func() {
@@ -54,6 +56,18 @@ var _ = Describe("StringHelpers", func() {
 			element := Element{Name: "Jennifer Lawrence"}
 			testField := reflect.ValueOf(element).Type().Field(0)
 			Expect(GetTagValueByName(testField, "talent")).To(Equal(""))
+		})
+
+		It("falls back to json tag", func() {
+			element := Element{FavoriteFood: "pizza"}
+			testField := reflect.ValueOf(element).Type().Field(1)
+			Expect(GetTagValueByName(testField, "name")).To(Equal("favorite_food"))
+		})
+
+		It("skips json tag -", func() {
+			element := Element{Color: "green"}
+			testField := reflect.ValueOf(element).Type().Field(2)
+			Expect(GetTagValueByName(testField, "name")).To(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
Implements falling back to `json` field tags if there is no `jsonapi` tag.

closes #206