### PR TITLE
Show UnmarshalInto dropping attributes set to null.

### DIFF
--- a/api.go
+++ b/api.go
@@ -693,6 +693,7 @@ func (res *resource) handleUpdate(c APIContexter, w http.ResponseWriter, r *http
 	}
 
 	err = jsonapi.UnmarshalInto(ctx, structType, &updatingObjs)
+
 	if err != nil {
 		return err
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -846,6 +846,15 @@ var _ = Describe("RestHandler", func() {
 				Expect(target.Value).To(Equal(null.FloatFrom(2)))
 			})
 
+			It("UPDATEs correctly using null.* values", func() {
+				target := source.posts["1"]
+				target.Value = null.FloatFrom(2)
+				doRequest(`{"data": {"id": "1", "attributes": {"title": "New Title", "value": null}, "type": "posts"}}`, "/v1/posts/1", "PATCH")
+				Expect(source.posts["1"].Title).To(Equal("New Title"))
+				Expect(target.Title).To(Equal("New Title"))
+				Expect(target.Value).To(Equal(null.FloatFromPtr(nil)))
+			})
+
 			It("Patch updates to-one relationships", func() {
 				target := source.posts["1"]
 				doRequest(`{


### PR DESCRIPTION
Below is the output of running this integration test and accompanying debug output. This PR demonstrates how in api.go's handleUpdate function the context (ctx) is unmarshaled using encoding/json and correctly contains the attribute named value being set to null. See the Context: below where value:interface{}(nil) is correct. But then after going through jsonapi.UnmarshalInto the nil value has been dropped and the test fails because the attribute was not updated.
```
Context: map[string]interface {}{"data":map[string]interface {}{"type":"posts", "id":"1", "attributes":map[string]interface {}{"title":"New Title", "value":interface {}(nil)}}}

Updated Obj: &{1 New Title {{2 true}} 0xc8205897e0 [{1 This is a stupid post!}] []}

------------------------------
• Failure [0.003 seconds]
RestHandler
/Users/dennis/Sites/go/src/github.com/api2go/api_test.go:1599
  when handling requests for pointer resources
  /Users/dennis/Sites/go/src/github.com/api2go/api_test.go:982
    Updating
    /Users/dennis/Sites/go/src/github.com/api2go/api_test.go:975
      UPDATEs correctly using null.* values [It]
      /Users/dennis/Sites/go/src/github.com/api2go/api_test.go:853

      Expected
          <null.Float>: {
              NullFloat64: {Float64: 2, Valid: true},
          }
      to equal
          <null.Float>: {
              NullFloat64: {Float64: 0, Valid: false},
          }

      /Users/dennis/Sites/go/src/github.com/api2go/api_test.go:852
```
