### PR TITLE
always take the type our of the ReferenceID struct

### DIFF
--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -245,7 +245,6 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 	}
 
 	for name, referenceIDs := range sortedResults {
-		referenceType := referenceIDs[0].Type
 		relationships[name] = map[string]interface{}{}
 		// if referenceType is plural, we need to use an array for data, otherwise it's just an object
 		if Pluralize(name) == name {
@@ -254,7 +253,7 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 
 			for _, referenceID := range referenceIDs {
 				data = append(data, map[string]interface{}{
-					"type": referenceType,
+					"type": referenceID.Type,
 					"id":   referenceID.ID,
 				})
 			}
@@ -263,7 +262,7 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 		} else {
 			relationships[name] = map[string]interface{}{
 				"data": map[string]interface{}{
-					"type": referenceType,
+					"type": referenceIDs[0].Type,
 					"id":   referenceIDs[0].ID,
 				},
 			}

--- a/jsonapi/marshal_different_to_many_test.go
+++ b/jsonapi/marshal_different_to_many_test.go
@@ -1,0 +1,80 @@
+package jsonapi
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type ManyParent struct {
+	ID      string `jsonapi:"-"`
+	Content string
+}
+
+func (m ManyParent) GetID() string {
+	return m.ID
+}
+
+func (m ManyParent) GetReferences() []Reference {
+	return []Reference{
+		{
+			Type: "childs",
+			Name: "childs",
+		},
+	}
+}
+
+func (m ManyParent) GetReferencedIDs() []ReferenceID {
+	return []ReferenceID{
+		{
+			Type: "childs",
+			Name: "childs",
+			ID:   "one",
+		},
+		{
+			Type: "other-childs",
+			Name: "childs",
+			ID:   "two",
+		},
+	}
+}
+
+var _ = Describe("Marshalling toMany relations with the same name and different types", func() {
+	var toMarshal ManyParent
+
+	BeforeEach(func() {
+		toMarshal = ManyParent{
+			ID:      "one",
+			Content: "test",
+		}
+	})
+
+	It("marshals toMany relationships with different type and same name", func() {
+		result, err := MarshalToJSON(toMarshal)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(MatchJSON(`
+    {
+      "data": {
+        "attributes": {
+          "content": "test"
+        },
+        "id": "one",
+        "relationships": {
+          "childs": {
+            "data": [
+            {
+              "id": "one",
+              "type": "childs"
+            },
+            {
+              "id": "two",
+              "type": "other-childs"
+            }
+            ]
+          }
+        },
+        "type": "manyParents"
+      }
+    }
+  `))
+	})
+})


### PR DESCRIPTION
when marshalling a toMany relationship with the same name but with different types in it, it was previously not possible to set the type for every referenced ID because it was assumed that it would always be of the same type. This is now possible.

Fixes #218 