### PR TITLE
Remove content marshalers from the api2go with gin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,6 @@ After that you can bootstrap api2go the following way:
     api := api2go.NewAPIWithRouting(
       "api",
       api2go.NewStaticResolver("/"),
-      api2go.DefaultContentMarshalers,
       gingonic.New(r),
     )
 


### PR DESCRIPTION
This change is the same as in https://github.com/manyminds/api2go-adapter/pull/4/files