### PR TITLE
Added InitializeObject hook

### DIFF
--- a/api.go
+++ b/api.go
@@ -562,6 +562,12 @@ func (res *resource) handleCreate(c APIContexter, w http.ResponseWriter, r *http
 	}
 	newObj := reflect.New(resourceType).Interface()
 
+	// Call InitializeObject if available to allow implementers change the object
+	// before calling Unmarshal.
+	if initSource, ok := res.source.(ObjectInitializer); ok {
+		initSource.InitializeObject(newObj)
+	}
+
 	err = jsonapi.Unmarshal(ctx, newObj)
 	if err != nil {
 		return NewHTTPError(nil, err.Error(), http.StatusNotAcceptable)

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -48,6 +48,14 @@ type FindAll interface {
 	FindAll(req Request) (Responder, error)
 }
 
+// The ObjectInitializer interface can be implemented to have the ability to change
+// a created object before Unmarshal is called. This is currently only called on
+// Create as the other actions go through FindOne or FindAll which are already
+// controlled by the implementer.
+type ObjectInitializer interface {
+	InitializeObject(interface{})
+}
+
 //URLResolver allows you to implement a static
 //way to return a baseURL for all incoming
 //requests for one api2go instance.

--- a/api_object_initializer_test.go
+++ b/api_object_initializer_test.go
@@ -1,0 +1,99 @@
+package api2go
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type ObjectInitializerResource struct{}
+
+func (s ObjectInitializerResource) InitializeObject(obj interface{}) {
+	if post, ok := obj.(*Post); ok {
+		post.Title = "New Title"
+	}
+}
+
+func (s ObjectInitializerResource) FindOne(ID string, req Request) (Responder, error) {
+	return nil, nil
+}
+
+func (s ObjectInitializerResource) Create(obj interface{}, req Request) (Responder, error) {
+	return &Response{Res: obj, Code: http.StatusCreated}, nil
+}
+
+func (s ObjectInitializerResource) Delete(ID string, req Request) (Responder, error) {
+	return nil, nil
+}
+
+func (s ObjectInitializerResource) Update(obj interface{}, req Request) (Responder, error) {
+	return nil, nil
+}
+
+var _ = Describe("Test resource implementing the ObjectInitializer interface", func() {
+	var (
+		api  *API
+		rec  *httptest.ResponseRecorder
+		body *strings.Reader
+	)
+	BeforeEach(func() {
+		api = NewAPI("v1")
+		api.AddResource(Post{}, ObjectInitializerResource{})
+		rec = httptest.NewRecorder()
+		body = strings.NewReader(`
+		{
+			"data": {
+				"attributes": {},
+				"id": "blubb",
+				"type": "posts"
+			}
+		}
+		`)
+	})
+
+	It("Create", func() {
+		req, err := http.NewRequest("POST", "/v1/posts", body)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+
+		Expect(rec.Body.String()).To(MatchJSON(`
+		{
+        	"data": {
+          		"type": "posts",
+          		"id": "blubb",
+          		"attributes": {
+					"title": "New Title",
+            		"value": null
+          		},
+          		"relationships": {
+					"author": {
+						"links": {
+							"self": "/v1/posts/blubb/relationships/author",
+							"related": "/v1/posts/blubb/author"
+						},
+						"data": null
+					},
+					"bananas": {
+						"links": {
+							"self": "/v1/posts/blubb/relationships/bananas",
+							"related": "/v1/posts/blubb/bananas"
+						},
+						"data": []
+					},
+					"comments": {
+						"links": {
+							"self": "/v1/posts/blubb/relationships/comments",
+							"related": "/v1/posts/blubb/comments"
+						},
+						"data": []
+					}
+          		}
+        	}
+     	}
+		`))
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+	})
+})


### PR DESCRIPTION
Hi there!

First of all thanks for this amazing library!

I'm working on a small very opinionated framework that uses struct tags to simplify the declaration of models. I first thought this might get very complicated with `api2go` as it uses `reflect` to create new objects internally. But in fact I learned that most actions go either through `crud.Find()` or `crud.FindAll()` which allows to setup the object before `jsonapi.Marshal()` or `jsonapi.Unmarshal()` is called. The situation that does not allow such access is on a PATCH request. An object gets created with `reflect` right before passing it to `jsonapi.Unmarshal()`.

TL;DR:
This pull request adds an optional method that can be implemented to get access to the dynamically created object in a PATCH request before `jsonapi.Unmarshal()` is called. This is necessary to give context to the models in higher frameworks that abstract the `jsonapi` interfaces.

Please feel free to change the name of the interface and method. ;)