### PR TITLE
FIX: replace getIncludedStructs(2) by filterDuplicates(2) method call

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -519,3 +519,41 @@ func (a Article) GetReferencedIDs() []ReferenceID {
 
 	return referenceIDs
 }
+
+type DeepDedendencies struct {
+	ID            string             `json:"-"`
+	Relationships []DeepDedendencies `json:"-"`
+}
+
+func (d DeepDedendencies) GetID() string {
+	return d.ID
+}
+
+func (DeepDedendencies) GetName() string {
+	return "deep"
+}
+
+func (d DeepDedendencies) GetReferences() []Reference {
+	return []Reference{{Type: "deep", Name: "deps"}}
+}
+
+func (d DeepDedendencies) GetReferencedIDs() []ReferenceID {
+	references := make([]ReferenceID, 0, len(d.Relationships))
+
+	for _, r := range d.Relationships {
+		references = append(references, ReferenceID{ID: r.ID, Type: "deep", Name: "deps"})
+	}
+
+	return references
+}
+
+func (d DeepDedendencies) GetReferencedStructs() []MarshalIdentifier {
+	var structs []MarshalIdentifier
+
+	for _, r := range d.Relationships {
+		structs = append(structs, r)
+		structs = append(structs, r.GetReferencedStructs()...)
+	}
+
+	return structs
+}

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -318,21 +318,6 @@ func getLinksForServerInformation(relationer MarshalLinkedRelations, name string
 	return links
 }
 
-func getIncludedStructs(included MarshalIncludedRelations, information ServerInformation) ([]Data, error) {
-	includedStructs := included.GetReferencedStructs()
-
-	result := make([]Data, len(includedStructs))
-
-	for i, includedStruct := range includedStructs {
-		err := marshalData(includedStruct, &result[i], information)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return result, nil
-}
-
 func marshalStruct(data MarshalIdentifier, information ServerInformation) (*Document, error) {
 	var contentData Data
 
@@ -349,7 +334,7 @@ func marshalStruct(data MarshalIdentifier, information ServerInformation) (*Docu
 
 	included, ok := data.(MarshalIncludedRelations)
 	if ok {
-		included, err := getIncludedStructs(included, information)
+		included, err := filterDuplicates(included.GetReferencedStructs(), information)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Single resource may have duplicates in `included` section when we fetch some deeper relations like in [spec](http://jsonapi.org/format/#fetching-includes)

For example we have post with 2 comments from same author and this request returns duplicated author for each comment:

```
Get /posts/1?include=comments.author
```
