### PR TITLE
Example: Create user with chocolate relationship

### DIFF
--- a/examples/crud_example_test.go
+++ b/examples/crud_example_test.go
@@ -176,6 +176,65 @@ var _ = Describe("CrudExample", func() {
 		`))
 	}
 
+	It("Creates a user with references chocolates", func() {
+		createChocolate()
+
+		rec = httptest.NewRecorder()
+		req, err := http.NewRequest("POST", "/v0/users", strings.NewReader(`
+    {
+      "data": {
+        "type": "users",
+        "attributes": {
+          "user-name": "marvin"
+        },
+        "relationships": {
+          "sweets": {
+            "data": [
+            {
+              "id": "1",
+              "type": "chocolates"
+            }
+            ]
+          }
+        }
+      }
+    }
+		`))
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+		Expect(rec.Body.String()).To(MatchJSON(`
+          {
+            "meta": {
+              "author": "The api2go examples crew",
+              "license": "wtfpl",
+              "license-url": "http://www.wtfpl.net"
+            },
+            "data": {
+              "id": "1",
+              "type": "users",
+              "attributes": {
+                "user-name": "marvin"
+              },
+              "relationships": {
+                "sweets": {
+                  "data": [
+                    {
+                      "id": "1",
+                      "type": "chocolates"
+                    }
+                  ],
+                  "links": {
+                    "related": "http://localhost:31415/v0/users/1/sweets",
+                    "self": "http://localhost:31415/v0/users/1/relationships/sweets"
+                  }
+                }
+              }
+            }
+          }
+          `))
+	})
+
 	It("Replaces users sweets", func() {
 		createUser()
 		createChocolate()

--- a/examples/model/model_user.go
+++ b/examples/model/model_user.go
@@ -41,9 +41,9 @@ func (u User) GetReferences() []jsonapi.Reference {
 // GetReferencedIDs to satisfy the jsonapi.MarshalLinkedRelations interface
 func (u User) GetReferencedIDs() []jsonapi.ReferenceID {
 	result := []jsonapi.ReferenceID{}
-	for _, chocolate := range u.Chocolates {
+	for _, chocolateID := range u.ChocolatesIDs {
 		result = append(result, jsonapi.ReferenceID{
-			ID:   chocolate.ID,
+			ID:   chocolateID,
 			Type: "chocolates",
 			Name: "sweets",
 		})


### PR DESCRIPTION
When requesting the users, the iteration was over models and not only the reference IDs which caused a bug that no references were in the response JSON when creating a user with some initial sweets.

#270 