### PR TITLE
Allow elements to implement custom links

### DIFF
--- a/api.go
+++ b/api.go
@@ -70,7 +70,7 @@ func (p paginationQueryParams) isValid() bool {
 }
 
 func (p paginationQueryParams) getLinks(r *http.Request, count uint, info information) (result jsonapi.Links, err error) {
-	result = jsonapi.Links{}
+	result = make(jsonapi.Links)
 
 	params := r.URL.Query()
 	prefix := ""
@@ -91,11 +91,11 @@ func (p paginationQueryParams) getLinks(r *http.Request, count uint, info inform
 		if p.number != "1" {
 			params.Set("page[number]", "1")
 			query, _ := url.QueryUnescape(params.Encode())
-			result.First = fmt.Sprintf("%s?%s", requestURL, query)
+			result["first"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 
 			params.Set("page[number]", strconv.FormatUint(number-1, 10))
 			query, _ = url.QueryUnescape(params.Encode())
-			result.Previous = fmt.Sprintf("%s?%s", requestURL, query)
+			result["prev"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 		}
 
 		// calculate last page number
@@ -113,11 +113,11 @@ func (p paginationQueryParams) getLinks(r *http.Request, count uint, info inform
 		if number != totalPages {
 			params.Set("page[number]", strconv.FormatUint(number+1, 10))
 			query, _ := url.QueryUnescape(params.Encode())
-			result.Next = fmt.Sprintf("%s?%s", requestURL, query)
+			result["next"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 
 			params.Set("page[number]", strconv.FormatUint(totalPages, 10))
 			query, _ = url.QueryUnescape(params.Encode())
-			result.Last = fmt.Sprintf("%s?%s", requestURL, query)
+			result["last"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 		}
 	} else {
 		// we have offset & limit params
@@ -134,7 +134,7 @@ func (p paginationQueryParams) getLinks(r *http.Request, count uint, info inform
 		if p.offset != "0" {
 			params.Set("page[offset]", "0")
 			query, _ := url.QueryUnescape(params.Encode())
-			result.First = fmt.Sprintf("%s?%s", requestURL, query)
+			result["first"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 
 			var prevOffset uint64
 			if limit > offset {
@@ -144,18 +144,18 @@ func (p paginationQueryParams) getLinks(r *http.Request, count uint, info inform
 			}
 			params.Set("page[offset]", strconv.FormatUint(prevOffset, 10))
 			query, _ = url.QueryUnescape(params.Encode())
-			result.Previous = fmt.Sprintf("%s?%s", requestURL, query)
+			result["prev"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 		}
 
 		// check if there are more entries to be loaded
 		if (offset + limit) < uint64(count) {
 			params.Set("page[offset]", strconv.FormatUint(offset+limit, 10))
 			query, _ := url.QueryUnescape(params.Encode())
-			result.Next = fmt.Sprintf("%s?%s", requestURL, query)
+			result["next"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 
 			params.Set("page[offset]", strconv.FormatUint(uint64(count)-limit, 10))
 			query, _ = url.QueryUnescape(params.Encode())
-			result.Last = fmt.Sprintf("%s?%s", requestURL, query)
+			result["last"] = jsonapi.Link{Href: fmt.Sprintf("%s?%s", requestURL, query)}
 		}
 	}
 

--- a/api.go
+++ b/api.go
@@ -926,7 +926,7 @@ func (res *resource) respondWithPagination(obj Responder, info information, stat
 		return err
 	}
 
-	data.Links = &links
+	data.Links = links
 	meta := obj.Metadata()
 	if len(meta) > 0 {
 		data.Meta = meta

--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -62,8 +62,8 @@ func (l *Link) UnmarshalJSON(payload []byte) error {
 		return json.Unmarshal(payload, &l.Href)
 	}
 
-	obj := make(map[string]interface{})
 	if bytes.HasPrefix(payload, objectSuffix) {
+		obj := make(map[string]interface{})
 		err := json.Unmarshal(payload, &obj)
 		if err != nil {
 			return err

--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -48,6 +48,15 @@ func (c *DataContainer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.DataObject)
 }
 
+// CustomLink represents a custom link for return in the document.
+type CustomLink struct {
+	Href string                 `json:"href"`
+	Meta map[string]interface{} `json:"meta,omitempty"`
+}
+
+// CustomLinks contains a map of CustomLink objects as given by an element.
+type CustomLinks map[string]CustomLink
+
 // Links is a general struct for document links and relationship links.
 type Links struct {
 	Self     string `json:"self,omitempty"`
@@ -64,7 +73,7 @@ type Data struct {
 	ID            string                  `json:"id"`
 	Attributes    json.RawMessage         `json:"attributes"`
 	Relationships map[string]Relationship `json:"relationships,omitempty"`
-	Links         *Links                  `json:"links,omitempty"`
+	Links         map[string]interface{}  `json:"links,omitempty"`
 }
 
 // Relationship contains reference IDs to the related structs

--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -49,15 +49,15 @@ func (c *DataContainer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.DataObject)
 }
 
-// CustomLink represents a custom link for return in the document.
-type CustomLink struct {
+// Link represents a link for return in the document.
+type Link struct {
 	Href string                 `json:"href"`
 	Meta map[string]interface{} `json:"meta,omitempty"`
 }
 
 // UnmarshalJSON marshals a string value into the Href field or marshals an
 // object value into the whole struct.
-func (l CustomLink) UnmarshalJSON(payload []byte) error {
+func (l Link) UnmarshalJSON(payload []byte) error {
 	if bytes.HasPrefix(payload, stringSuffix) {
 		return json.Unmarshal(payload, &l.Href)
 	}
@@ -71,7 +71,7 @@ func (l CustomLink) UnmarshalJSON(payload []byte) error {
 
 // MarshalJSON returns the JSON encoding of only the Href field if the Meta
 // field is empty, otherwise it marshals the whole struct.
-func (l CustomLink) MarshalJSON() ([]byte, error) {
+func (l Link) MarshalJSON() ([]byte, error) {
 	if len(l.Meta) == 0 {
 		return json.Marshal(l.Href)
 	}
@@ -81,18 +81,8 @@ func (l CustomLink) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// CustomLinks contains a map of CustomLink objects as given by an element.
-type CustomLinks map[string]CustomLink
-
-// Links is a general struct for document links and relationship links.
-type Links struct {
-	Self     string `json:"self,omitempty"`
-	Related  string `json:"related,omitempty"`
-	First    string `json:"first,omitempty"`
-	Previous string `json:"prev,omitempty"`
-	Next     string `json:"next,omitempty"`
-	Last     string `json:"last,omitempty"`
-}
+// Links contains a map of custom Link objects as given by an element.
+type Links map[string]Link
 
 // Data is a general struct for document data and included data.
 type Data struct {
@@ -100,7 +90,7 @@ type Data struct {
 	ID            string                  `json:"id"`
 	Attributes    json.RawMessage         `json:"attributes"`
 	Relationships map[string]Relationship `json:"relationships,omitempty"`
-	Links         map[string]interface{}  `json:"links,omitempty"`
+	Links         Links                   `json:"links,omitempty"`
 }
 
 // Relationship contains reference IDs to the related structs

--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -12,7 +12,7 @@ var stringSuffix = []byte(`"`)
 
 // A Document represents a JSON API document as specified here: http://jsonapi.org.
 type Document struct {
-	Links    *Links                 `json:"links,omitempty"`
+	Links    Links                  `json:"links,omitempty"`
 	Data     *DataContainer         `json:"data"`
 	Included []Data                 `json:"included,omitempty"`
 	Meta     map[string]interface{} `json:"meta,omitempty"`
@@ -95,7 +95,7 @@ type Data struct {
 
 // Relationship contains reference IDs to the related structs
 type Relationship struct {
-	Links *Links                     `json:"links,omitempty"`
+	Links Links                      `json:"links,omitempty"`
 	Data  *RelationshipDataContainer `json:"data,omitempty"`
 	Meta  map[string]interface{}     `json:"meta,omitempty"`
 }

--- a/jsonapi/data_structs_test.go
+++ b/jsonapi/data_structs_test.go
@@ -215,9 +215,21 @@ var _ = Describe("JSONAPI Struct tests", func() {
 		})
 
 		It("unmarshals with an error for syntax error", func() {
-			err := json.Unmarshal([]byte(`{`), &Link{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unexpected end of JSON input"))
+			badPayloads := []string{`{`, `"`}
+			for _, payload := range badPayloads {
+				err := json.Unmarshal([]byte(payload), &Link{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("unexpected end of JSON input"))
+			}
+		})
+
+		It("unmarshals with an error for wrong types", func() {
+			badPayloads := []string{`null`, `13`, `[]`}
+			for _, payload := range badPayloads {
+				err := json.Unmarshal([]byte(payload), &Link{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("expected a JSON encoded string or object"))
+			}
 		})
 	})
 })

--- a/jsonapi/data_structs_test.go
+++ b/jsonapi/data_structs_test.go
@@ -160,4 +160,64 @@ var _ = Describe("JSONAPI Struct tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(target.Data.DataArray).To(Equal([]Data{expectedData}))
 	})
+
+	Context("Marshal and Unmarshal link structs", func() {
+		It("marshals to a string with no metadata", func() {
+			link := Link{Href: "test link"}
+			ret, err := json.Marshal(&link)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(MatchJSON(`"test link"`))
+		})
+
+		It("marshals to an object with metadata", func() {
+			link := Link{
+				Href: "test link",
+				Meta: map[string]interface{}{
+					"test": "data",
+				},
+			}
+			ret, err := json.Marshal(&link)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(MatchJSON(`{
+				"href": "test link",
+				"meta": {"test": "data"}
+			}`))
+		})
+
+		It("unmarshals from a string", func() {
+			expected := Link{Href: "test link"}
+			target := Link{}
+			err := json.Unmarshal([]byte(`"test link"`), &target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal(expected))
+		})
+
+		It("unmarshals from an object", func() {
+			expected := Link{
+				Href: "test link",
+				Meta: map[string]interface{}{
+					"test": "data",
+				},
+			}
+			target := Link{}
+			err := json.Unmarshal([]byte(`{
+				"href": "test link",
+				"meta": {"test": "data"}
+			}`), &target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal(expected))
+		})
+
+		It("unmarshals with an error when href is missing", func() {
+			err := json.Unmarshal([]byte(`{}`), &Link{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(`link object expects a "href" key`))
+		})
+
+		It("unmarshals with an error for syntax error", func() {
+			err := json.Unmarshal([]byte(`{`), &Link{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unexpected end of JSON input"))
+		})
+	})
 })

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -440,6 +440,32 @@ func (i PrefixServerInformation) GetPrefix() string {
 	return prefix
 }
 
+type CustomLinksPost struct{}
+
+func (n CustomLinksPost) GetID() string {
+	return "someID"
+}
+
+func (n *CustomLinksPost) SetID(ID string) error {
+	return nil
+}
+
+func (n CustomLinksPost) GetName() string {
+	return "posts"
+}
+
+func (n CustomLinksPost) GetCustomLinks(base string) CustomLinks {
+	return CustomLinks{
+		"someLink": CustomLink{Href: base + `/someLink`},
+		"otherLink": CustomLink{
+			Href: base + `/otherLink`,
+			Meta: map[string]interface{}{
+				"method": "GET",
+			},
+		},
+	}
+}
+
 type NoRelationshipPosts struct{}
 
 func (n NoRelationshipPosts) GetID() string {

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -454,10 +454,10 @@ func (n CustomLinksPost) GetName() string {
 	return "posts"
 }
 
-func (n CustomLinksPost) GetCustomLinks(base string) CustomLinks {
-	return CustomLinks{
-		"someLink": CustomLink{Href: base + `/someLink`},
-		"otherLink": CustomLink{
+func (n CustomLinksPost) GetCustomLinks(base string) Links {
+	return Links{
+		"someLink": Link{Href: base + `/someLink`},
+		"otherLink": Link{
 			Href: base + `/otherLink`,
 			Meta: map[string]interface{}{
 				"method": "GET",

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -330,7 +330,7 @@ func getLinkBaseURL(element MarshalIdentifier, information ServerInformation) st
 	return fmt.Sprintf("%s/%s/%s", prefix, structType, element.GetID())
 }
 
-func getLinksForServerInformation(relationer MarshalLinkedRelations, name string, information ServerInformation) *Links {
+func getLinksForServerInformation(relationer MarshalLinkedRelations, name string, information ServerInformation) Links {
 	if information == nil {
 		return nil
 	}
@@ -341,7 +341,7 @@ func getLinksForServerInformation(relationer MarshalLinkedRelations, name string
 	links["self"] = Link{Href: fmt.Sprintf("%s/relationships/%s", base, name)}
 	links["related"] = Link{Href: fmt.Sprintf("%s/%s", base, name)}
 
-	return &links
+	return links
 }
 
 func marshalStruct(data MarshalIdentifier, information ServerInformation) (*Document, error) {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -77,7 +77,7 @@ type MarshalIncludedRelations interface {
 // want any custom links.
 type MarshalCustomLinks interface {
 	MarshalIdentifier
-	GetCustomLinks(string) CustomLinks
+	GetCustomLinks(string) Links
 }
 
 // A ServerInformation implementor can be passed to MarshalWithURLs to generate
@@ -214,7 +214,7 @@ func marshalData(element MarshalIdentifier, data *Data, information ServerInform
 	if information != nil {
 		if customLinks, ok := element.(MarshalCustomLinks); ok {
 			if data.Links == nil {
-				data.Links = make(map[string]interface{})
+				data.Links = make(Links)
 			}
 			base := getLinkBaseURL(element, information)
 			for k, v := range customLinks.GetCustomLinks(base) {
@@ -335,13 +335,13 @@ func getLinksForServerInformation(relationer MarshalLinkedRelations, name string
 		return nil
 	}
 
-	links := &Links{}
+	links := make(Links)
 	base := getLinkBaseURL(relationer, information)
 
-	links.Self = fmt.Sprintf("%s/relationships/%s", base, name)
-	links.Related = fmt.Sprintf("%s/%s", base, name)
+	links["self"] = Link{Href: fmt.Sprintf("%s/relationships/%s", base, name)}
+	links["related"] = Link{Href: fmt.Sprintf("%s/%s", base, name)}
 
-	return links
+	return &links
 }
 
 func marshalStruct(data MarshalIdentifier, information ServerInformation) (*Document, error) {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -213,10 +213,14 @@ func marshalData(element MarshalIdentifier, data *Data, information ServerInform
 
 	if information != nil {
 		if customLinks, ok := element.(MarshalCustomLinks); ok {
-			data.Links = make(map[string]interface{})
+			if data.Links == nil {
+				data.Links = make(map[string]interface{})
+			}
 			base := getLinkBaseURL(element, information)
 			for k, v := range customLinks.GetCustomLinks(base) {
-				data.Links[k] = v
+				if _, ok := data.Links[k]; !ok {
+					data.Links[k] = v
+				}
 			}
 		}
 	}

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -11,6 +11,28 @@ import (
 )
 
 var _ = Describe("Marshalling", func() {
+	Context("When marshaling objects with custom links", func() {
+		It("contains the custom links in the marshaled data", func() {
+			post := CustomLinksPost{}
+			i, err := MarshalWithURLs(post, CompleteServerInformation{})
+			Expect(err).To(BeNil())
+			Expect(i).To(MatchJSON(`{
+				"data": {
+					"type": "posts",
+					"id": "someID",
+					"attributes": {},
+					"links": {
+						"someLink": {"href": "http://my.domain/v1/posts/someID/someLink"},
+						"otherLink": {
+							"href": "http://my.domain/v1/posts/someID/otherLink",
+							"meta": {"method": "GET"}
+						}
+					}
+				}
+			}`))
+		})
+	})
+
 	Context("When marshaling simple objects", func() {
 		var (
 			firstPost, secondPost SimplePost
@@ -218,6 +240,28 @@ var _ = Describe("Marshalling", func() {
 			_, err := Marshal(comment)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("MarshalIdentifier must not be nil"))
+		})
+	})
+
+	Context("When marshaling objects with custom links", func() {
+		It("contains the custom links in the marshaled data", func() {
+			post := CustomLinksPost{}
+			i, err := MarshalWithURLs(post, CompleteServerInformation{})
+			Expect(err).To(BeNil())
+			Expect(i).To(MatchJSON(`{
+				"data": {
+					"type": "posts",
+					"id": "someID",
+					"attributes": {},
+					"links": {
+						"someLink": {"href": "http://my.domain/v1/posts/someID/someLink"},
+						"otherLink": {
+							"href": "http://my.domain/v1/posts/someID/otherLink",
+							"meta": {"method": "GET"}
+						}
+					}
+				}
+			}`))
 		})
 	})
 

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -11,28 +11,6 @@ import (
 )
 
 var _ = Describe("Marshalling", func() {
-	Context("When marshaling objects with custom links", func() {
-		It("contains the custom links in the marshaled data", func() {
-			post := CustomLinksPost{}
-			i, err := MarshalWithURLs(post, CompleteServerInformation{})
-			Expect(err).To(BeNil())
-			Expect(i).To(MatchJSON(`{
-				"data": {
-					"type": "posts",
-					"id": "someID",
-					"attributes": {},
-					"links": {
-						"someLink": {"href": "http://my.domain/v1/posts/someID/someLink"},
-						"otherLink": {
-							"href": "http://my.domain/v1/posts/someID/otherLink",
-							"meta": {"method": "GET"}
-						}
-					}
-				}
-			}`))
-		})
-	})
-
 	Context("When marshaling simple objects", func() {
 		var (
 			firstPost, secondPost SimplePost
@@ -254,7 +232,7 @@ var _ = Describe("Marshalling", func() {
 					"id": "someID",
 					"attributes": {},
 					"links": {
-						"someLink": {"href": "http://my.domain/v1/posts/someID/someLink"},
+						"someLink": "http://my.domain/v1/posts/someID/someLink",
 						"otherLink": {
 							"href": "http://my.domain/v1/posts/someID/otherLink",
 							"meta": {"method": "GET"}

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -882,7 +882,7 @@ var _ = Describe("Marshalling", func() {
 						Type: "users",
 					},
 				},
-				Links: &Links{
+				Links: Links{
 					"self":    Link{Href: "http://my.domain/v1/posts/1/relationships/author"},
 					"related": Link{Href: "http://my.domain/v1/posts/1/author"},
 				},
@@ -898,7 +898,7 @@ var _ = Describe("Marshalling", func() {
 						Type: "users",
 					},
 				},
-				Links: &Links{
+				Links: Links{
 					"self":    Link{Href: "http://my.domain/posts/1/relationships/author"},
 					"related": Link{Href: "http://my.domain/posts/1/author"},
 				},
@@ -914,7 +914,7 @@ var _ = Describe("Marshalling", func() {
 						Type: "users",
 					},
 				},
-				Links: &Links{
+				Links: Links{
 					"self":    Link{Href: "/v1/posts/1/relationships/author"},
 					"related": Link{Href: "/v1/posts/1/author"},
 				},

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -883,8 +883,8 @@ var _ = Describe("Marshalling", func() {
 					},
 				},
 				Links: &Links{
-					Self:    "http://my.domain/v1/posts/1/relationships/author",
-					Related: "http://my.domain/v1/posts/1/author",
+					"self":    Link{Href: "http://my.domain/v1/posts/1/relationships/author"},
+					"related": Link{Href: "http://my.domain/v1/posts/1/author"},
 				},
 			}))
 		})
@@ -899,8 +899,8 @@ var _ = Describe("Marshalling", func() {
 					},
 				},
 				Links: &Links{
-					Self:    "http://my.domain/posts/1/relationships/author",
-					Related: "http://my.domain/posts/1/author",
+					"self":    Link{Href: "http://my.domain/posts/1/relationships/author"},
+					"related": Link{Href: "http://my.domain/posts/1/author"},
 				},
 			}))
 		})
@@ -915,8 +915,8 @@ var _ = Describe("Marshalling", func() {
 					},
 				},
 				Links: &Links{
-					Self:    "/v1/posts/1/relationships/author",
-					Related: "/v1/posts/1/author",
+					"self":    Link{Href: "/v1/posts/1/relationships/author"},
+					"related": Link{Href: "/v1/posts/1/author"},
 				},
 			}))
 		})


### PR DESCRIPTION
If this is merged, structs may implement methods like the following:

```go
func (s MyStruct) GetCustomLinks(base string) jsonapi.CustomLinks {
    return jsonapi.CustomLinks{
        "firstlink": jsonapi.CustomLink{Href: base + `/firstlink`},
        "secondlink": jsonapi.CustomLink{
            Href: base + `/secondlink`,
            Meta: map[string]interface{}{"method": "GET"},
        },
    }
}
```

The [`"links"` object documentation](http://jsonapi.org/format/#document-links) does not specify whether or not custom links are allowed, only that additional standard links may be added in the future. However, custom links are useful for discoverability of additional services the resource may provide, when behavior extends beyond basic CRUD.

Notes:
* As the `"links"` object is not currently used when marshaling the data payload elements (only top-level and relationship `"links"` are currently used) I did not implement a merge strategy. If the `"links"` object is eventually to be populated with links (such as `"self"`) in the future, a merge strategy would have to be implemented.