### PR TITLE
Support for custom pagination logic

### DIFF
--- a/api.go
+++ b/api.go
@@ -427,25 +427,24 @@ func (res *resource) marshalResponse(resp interface{}, w http.ResponseWriter, st
 }
 
 func (res *resource) handleIndex(c APIContexter, w http.ResponseWriter, r *http.Request, info information) error {
-	pagination := newPaginationQueryParams(r)
-	if pagination.isValid() {
-		source, ok := res.source.(PaginatedFindAll)
-		if !ok {
-			return NewHTTPError(nil, "Resource does not implement the PaginatedFindAll interface", http.StatusNotFound)
-		}
+	if source, ok := res.source.(PaginatedFindAll); ok {
+		pagination := newPaginationQueryParams(r)
 
-		count, response, err := source.PaginatedFindAll(buildRequest(c, r))
-		if err != nil {
-			return err
-		}
+		if pagination.isValid() {
+			count, response, err := source.PaginatedFindAll(buildRequest(c, r))
+			if err != nil {
+				return err
+			}
 
-		paginationLinks, err := pagination.getLinks(r, count, info)
-		if err != nil {
-			return err
-		}
+			paginationLinks, err := pagination.getLinks(r, count, info)
+			if err != nil {
+				return err
+			}
 
-		return res.respondWithPagination(response, info, http.StatusOK, paginationLinks, w, r)
+			return res.respondWithPagination(response, info, http.StatusOK, paginationLinks, w, r)
+		}
 	}
+
 	source, ok := res.source.(FindAll)
 	if !ok {
 		return NewHTTPError(nil, "Resource does not implement the FindAll interface", http.StatusNotFound)

--- a/api.go
+++ b/api.go
@@ -22,7 +22,10 @@ const (
 	defaultContentTypHeader = "application/vnd.api+json"
 )
 
-var queryFieldsRegex = regexp.MustCompile(`^fields\[(\w+)\]$`)
+var (
+	queryPageRegex   = regexp.MustCompile(`^page\[(\w+)\]$`)
+	queryFieldsRegex = regexp.MustCompile(`^fields\[(\w+)\]$`)
+)
 
 type information struct {
 	prefix   string
@@ -404,9 +407,15 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source CRUD) *r
 func buildRequest(c APIContexter, r *http.Request) Request {
 	req := Request{PlainRequest: r}
 	params := make(map[string][]string)
+	pagination := make(map[string]string)
 	for key, values := range r.URL.Query() {
 		params[key] = strings.Split(values[0], ",")
+		pageMatches := queryPageRegex.FindStringSubmatch(key)
+		if len(pageMatches) > 1 {
+			pagination[pageMatches[1]] = values[0]
+		}
 	}
+	req.Pagination = pagination
 	req.QueryParams = params
 	req.Header = r.Header
 	req.Context = c
@@ -505,26 +514,23 @@ func (res *resource) handleLinked(c APIContexter, api *API, w http.ResponseWrite
 			request.QueryParams[res.name+"ID"] = []string{id}
 			request.QueryParams[res.name+"Name"] = []string{linked.Name}
 
-			// check for pagination, otherwise normal FindAll
-			pagination := newPaginationQueryParams(r)
-			if pagination.isValid() {
-				source, ok := resource.source.(PaginatedFindAll)
-				if !ok {
-					return NewHTTPError(nil, "Resource does not implement the PaginatedFindAll interface", http.StatusNotFound)
-				}
+			if source, ok := resource.source.(PaginatedFindAll); ok {
+				// check for pagination, otherwise normal FindAll
+				pagination := newPaginationQueryParams(r)
+				if pagination.isValid() {
+					var count uint
+					count, response, err := source.PaginatedFindAll(request)
+					if err != nil {
+						return err
+					}
 
-				var count uint
-				count, response, err := source.PaginatedFindAll(request)
-				if err != nil {
-					return err
-				}
+					paginationLinks, err := pagination.getLinks(r, count, info)
+					if err != nil {
+						return err
+					}
 
-				paginationLinks, err := pagination.getLinks(r, count, info)
-				if err != nil {
-					return err
+					return res.respondWithPagination(response, info, http.StatusOK, paginationLinks, w, r)
 				}
-
-				return res.respondWithPagination(response, info, http.StatusOK, paginationLinks, w, r)
 			}
 
 			source, ok := resource.source.(FindAll)
@@ -914,6 +920,15 @@ func (res *resource) respondWith(obj Responder, info information, status int, w 
 	meta := obj.Metadata()
 	if len(meta) > 0 {
 		data.Meta = meta
+	}
+
+	if objWithLinks, ok := obj.(LinksResponder); ok {
+		baseURL := strings.Trim(info.GetBaseURL(), "/")
+		requestURL := fmt.Sprintf("%s%s", baseURL, r.URL.Path)
+		links := objWithLinks.Links(r, requestURL)
+		if len(links) > 0 {
+			data.Links = links
+		}
 	}
 
 	return res.marshalResponse(data, w, status, r)

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -1,6 +1,10 @@
 package api2go
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/manyminds/api2go/jsonapi"
+)
 
 // The CRUD interface MUST be implemented in order to use the api2go api.
 // Use Responder for success status codes and content/meta data. In case of an error,
@@ -31,6 +35,14 @@ type CRUD interface {
 	// - 202 Accepted: Processing is delayed, return nothing
 	// - 204 No Content: Update was successful, no fields were changed by the server, return nothing
 	Update(obj interface{}, req Request) (Responder, error)
+}
+
+// Pagination represents information needed to return pagination links
+type Pagination struct {
+	Next  map[string]string
+	Prev  map[string]string
+	First map[string]string
+	Last  map[string]string
 }
 
 // The PaginatedFindAll interface can be optionally implemented to fetch a subset of all records.
@@ -87,4 +99,11 @@ type Responder interface {
 	Metadata() map[string]interface{}
 	Result() interface{}
 	StatusCode() int
+}
+
+// The LinksResponder interface may be used when the response object is able to return
+// a set of links for the top-level response object.
+type LinksResponder interface {
+	Responder
+	Links(*http.Request, string) jsonapi.Links
 }

--- a/request.go
+++ b/request.go
@@ -6,6 +6,7 @@ import "net/http"
 type Request struct {
 	PlainRequest *http.Request
 	QueryParams  map[string][]string
+	Pagination   map[string]string
 	Header       http.Header
 	Context      APIContexter
 }

--- a/response.go
+++ b/response.go
@@ -40,12 +40,11 @@ func buildLink(base string, r *http.Request, pagination map[string]string) jsona
 		qk := fmt.Sprintf("page[%s]", k)
 		params.Set(qk, v)
 	}
-	if len(params) > 0 {
-		query, _ := url.QueryUnescape(params.Encode())
-		return jsonapi.Link{Href: fmt.Sprintf("%s?%s", base, query)}
-	} else {
+	if len(params) == 0 {
 		return jsonapi.Link{Href: base}
 	}
+	query, _ := url.QueryUnescape(params.Encode())
+	return jsonapi.Link{Href: fmt.Sprintf("%s?%s", base, query)}
 }
 
 // Links returns a jsonapi.Links object to include in the top-level response

--- a/response.go
+++ b/response.go
@@ -1,13 +1,22 @@
 package api2go
 
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/manyminds/api2go/jsonapi"
+)
+
 // The Response struct implements api2go.Responder and can be used as a default
 // implementation for your responses
 // you can fill the field `Meta` with all the metadata your application needs
 // like license, tokens, etc
 type Response struct {
-	Res  interface{}
-	Code int
-	Meta map[string]interface{}
+	Res        interface{}
+	Code       int
+	Meta       map[string]interface{}
+	Pagination Pagination
 }
 
 // Metadata returns additional meta data
@@ -23,4 +32,37 @@ func (r Response) Result() interface{} {
 // StatusCode sets the return status code
 func (r Response) StatusCode() int {
 	return r.Code
+}
+
+func buildLink(base string, r *http.Request, pagination map[string]string) jsonapi.Link {
+	params := r.URL.Query()
+	for k, v := range pagination {
+		qk := fmt.Sprintf("page[%s]", k)
+		params.Set(qk, v)
+	}
+	if len(params) > 0 {
+		query, _ := url.QueryUnescape(params.Encode())
+		return jsonapi.Link{Href: fmt.Sprintf("%s?%s", base, query)}
+	} else {
+		return jsonapi.Link{Href: base}
+	}
+}
+
+// Links returns a jsonapi.Links object to include in the top-level response
+func (r Response) Links(req *http.Request, baseURL string) (ret jsonapi.Links) {
+	ret = make(jsonapi.Links)
+
+	if r.Pagination.Next != nil {
+		ret["next"] = buildLink(baseURL, req, r.Pagination.Next)
+	}
+	if r.Pagination.Prev != nil {
+		ret["prev"] = buildLink(baseURL, req, r.Pagination.Prev)
+	}
+	if r.Pagination.First != nil {
+		ret["first"] = buildLink(baseURL, req, r.Pagination.First)
+	}
+	if r.Pagination.Last != nil {
+		ret["last"] = buildLink(baseURL, req, r.Pagination.Last)
+	}
+	return
 }


### PR DESCRIPTION
First, adds a `Pagination` map to `api2go.Request` that extracts any pagination query parameters. E.g. `?page[test]=stuff` would contain `{"test": "stuff"}`.

Next, it removes the error if pagination fields are given and `PaginatedFindAll` is not implemented. Instead, it calls `FindAll` as normal. This allows the "supported" pagination params (page/size/offset/limit) to be used with custom pagination logic.

Finally, it adds a `Pagination` struct to `api2go.Response` that can control the pagination links returned by the regular `FindAll` method. This allows `FindAll` to return something like this:

```golang
return &api2go.Response{
    // ...,
    Pagination: api2go.Pagination{
        Next: map[string]string{"cursor": "nextpage"},  // ...?page[cursor]=nextpage
        Prev: map[string]string{"cursor": "prevpage"},  // ...?page[cursor]=prevpage
        First: map[string]string{"cursor": ""},
        // no "last" link because Last: field was not given
    },
}
```

I believe this provides very flexible usage without a lot of overhead, and should be backwards compatible with existing code. I did not like using `PaginatedFindAll` because when dealing with large datasets returning the `"last"` link is not always feasible or desired, so I tried to leave it in place while allowing me to control pagination as desired.