### PR TITLE
Added support for custom meta info in relations.

### DIFF
--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -95,6 +95,9 @@ func (l Link) MarshalJSON() ([]byte, error) {
 // Links contains a map of custom Link objects as given by an element.
 type Links map[string]Link
 
+// Metas contains a map of maps of meta objects as given by an element.
+type Metas map[string]map[string]interface{}
+
 // Data is a general struct for document data and included data.
 type Data struct {
 	Type          string                  `json:"type"`

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -495,9 +495,9 @@ func (n CustomMetaPost) GetReferencedIDs() []ReferenceID {
 }
 
 func (n CustomMetaPost) GetCustomMeta(linkURL string) Metas {
-	meta := map[string]map[string]interface{} {
-		"author": map[string]interface{} {
-			"someMetaKey": "someMetaValue",
+	meta := map[string]map[string]interface{}{
+		"author": {
+			"someMetaKey":      "someMetaValue",
 			"someOtherMetaKey": "someOtherMetaValue",
 		},
 	}

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -466,6 +466,44 @@ func (n CustomLinksPost) GetCustomLinks(base string) Links {
 	}
 }
 
+type CustomMetaPost struct{}
+
+func (n CustomMetaPost) GetID() string {
+	return "someID"
+}
+
+func (n *CustomMetaPost) SetID(ID string) error {
+	return nil
+}
+
+func (n CustomMetaPost) GetName() string {
+	return "posts"
+}
+
+func (n CustomMetaPost) GetReferences() []Reference {
+	return []Reference{
+		{
+			Type:        "users",
+			Name:        "author",
+			IsNotLoaded: true,
+		},
+	}
+}
+
+func (n CustomMetaPost) GetReferencedIDs() []ReferenceID {
+	return nil
+}
+
+func (n CustomMetaPost) GetCustomMeta(linkURL string) Metas {
+	meta := map[string]map[string]interface{} {
+		"author": map[string]interface{} {
+			"someMetaKey": "someMetaValue",
+			"someOtherMetaKey": "someOtherMetaValue",
+		},
+	}
+	return meta
+}
+
 type NoRelationshipPosts struct{}
 
 func (n NoRelationshipPosts) GetID() string {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -311,7 +311,7 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 		relationship := Relationship{
 			Data:  &container,
 			Links: links,
-			Meta: meta,
+			Meta:  meta,
 		}
 
 		relationships[name] = relationship
@@ -339,7 +339,7 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 
 		relationship := Relationship{
 			Links: links,
-			Meta: meta,
+			Meta:  meta,
 		}
 
 		// skip relationship data completely if IsNotLoaded is set

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -80,6 +80,13 @@ type MarshalCustomLinks interface {
 	GetCustomLinks(string) Links
 }
 
+// The MarshalCustomRelationshipMeta interface can be implemented if the struct should
+// want a custom meta in a relationship.
+type MarshalCustomRelationshipMeta interface {
+	MarshalIdentifier
+	GetCustomMeta(string) Metas
+}
+
 // A ServerInformation implementor can be passed to MarshalWithURLs to generate
 // the `self` and `related` urls inside `links`.
 type ServerInformation interface {
@@ -240,6 +247,19 @@ func isToMany(relationshipType RelationshipType, name string) bool {
 	return relationshipType == ToManyRelationship
 }
 
+func getMetaForRelation(metaSource MarshalCustomRelationshipMeta, name string, information ServerInformation) map[string]interface{} {
+	meta := make(map[string]interface{})
+	base := getLinkBaseURL(metaSource, information)
+	if metaMap, ok := metaSource.GetCustomMeta(base)[name]; ok {
+		for k, v := range metaMap {
+			if _, ok := meta[k]; !ok {
+				meta[k] = v
+			}
+		}
+	}
+	return meta
+}
+
 func getStructRelationships(relationer MarshalLinkedRelations, information ServerInformation) map[string]Relationship {
 	referencedIDs := relationer.GetReferencedIDs()
 	sortedResults := map[string][]ReferenceID{}
@@ -282,9 +302,16 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 		// set URLs if necessary
 		links := getLinksForServerInformation(relationer, name, information)
 
+		// get the custom meta for this relationship
+		var meta map[string]interface{}
+		if customMetaSource, ok := relationer.(MarshalCustomRelationshipMeta); ok {
+			meta = getMetaForRelation(customMetaSource, name, information)
+		}
+
 		relationship := Relationship{
 			Data:  &container,
 			Links: links,
+			Meta: meta,
 		}
 
 		relationships[name] = relationship
@@ -303,8 +330,16 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 		}
 
 		links := getLinksForServerInformation(relationer, name, information)
+
+		// get the custom meta for this relationship
+		var meta map[string]interface{}
+		if customMetaSource, ok := relationer.(MarshalCustomRelationshipMeta); ok {
+			meta = getMetaForRelation(customMetaSource, name, information)
+		}
+
 		relationship := Relationship{
 			Links: links,
+			Meta: meta,
 		}
 
 		// skip relationship data completely if IsNotLoaded is set

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -243,6 +243,33 @@ var _ = Describe("Marshalling", func() {
 		})
 	})
 
+	Context("When marshaling objects with custom meta", func() {
+		It("contains the custom meta in the marshaled data", func() {
+			post := CustomMetaPost{}
+			i, err := MarshalWithURLs(post, CompleteServerInformation{})
+			Expect(err).To(BeNil())
+			Expect(i).To(MatchJSON(`{
+				"data": {
+					"type": "posts",
+					"id": "someID",
+					"attributes": {},
+					"relationships": {
+							"author": {
+								"links": {
+									"self": "http://my.domain/v1/posts/someID/relationships/author",
+									"related": "http://my.domain/v1/posts/someID/author"
+								},
+								"meta": {
+									"someMetaKey": "someMetaValue",
+									"someOtherMetaKey": "someOtherMetaValue"
+								}
+							}
+					}
+				}
+			}`))
+		})
+	})
+
 	Context("When marshaling compound objects", func() {
 		It("marshals nested objects", func() {
 			comment1 := Comment{ID: 1, Text: "First!"}


### PR DESCRIPTION
This adds custom meta support for relations:
```
"relationships": {
  "author": {
    "links": {
      "self": "http://my.domain/v1/posts/someID/relationships/author",
      "related": "http://my.domain/v1/posts/someID/author"
    },
    "meta": {
      "someMetaKey": "someMetaValue",
      "someOtherMetaKey": "someOtherMetaValue"
    }
  }
}
```
To use this feature, a type has to implement `MarshalCustomRelationshipMeta` and return the meta structure for the type's relations from `GetCustomMeta()`:
```
type MarshalCustomRelationshipMeta interface {
	MarshalIdentifier
	GetCustomMeta(string) Metas
}
```
A test is included.