### PR TITLE
Split CRUD interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ If you need api2go with any different go framework, just send a PR with the acco
 ## Building a REST API
 
 First, write an implementation of either `api2go.ResourceGetter`, `api2go.ResourceCreator`, `api2go.ResourceUpdater`,  `api2go.ResourceDeleter`, or any combination of them.
+You can also write an implementation the `CRUD` interface which embed all of them.
 You have to implement at least one of these 4 methods:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -372,7 +372,8 @@ If you need api2go with any different go framework, just send a PR with the acco
 
 ## Building a REST API
 
-First, write an implementation of `api2go.CRUD`. You have to implement at least these 4 methods:
+First, write an implementation of either `api2go.ResourceGetter`, `api2go.ResourceCreator`, `api2go.ResourceUpdater`,  `api2go.ResourceDeleter`, or any combination of them.
+You have to implement at least one of these 4 methods:
 
 ```go
 type fixtureSource struct {}
@@ -469,7 +470,7 @@ type EditToManyRelations interface {
 
 All PATCH, POST and DELETE routes do a `FindOne` and update the values/relations in the previously found struct. This
 struct will then be passed on to the `Update` method of a resource struct. So you get all these routes "for free" and just
-have to implement the CRUD Update method.
+have to implement the `ResourceUpdater` `Update` method.
 
 ### Query Params
 To support all the features mentioned in the `Fetching Resources` section of Jsonapi:

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -13,6 +13,13 @@ type ResourceGetter interface {
 	FindOne(ID string, req Request) (Responder, error)
 }
 
+// The CRUD interface embed all interfaces at once: `ResourceCreator`, `ResourceDeleter`, `ResourceUpdater` (which includes `ResourceGetter`)
+type CRUD interface {
+	ResourceCreator
+	ResourceDeleter
+	ResourceUpdater
+}
+
 // The ResourceCreator interface MUST be implemented in order to generate the POST route
 type ResourceCreator interface {
 	// Create a new object. Newly created object/struct must be in Responder.

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -6,14 +6,13 @@ import (
 	"github.com/manyminds/api2go/jsonapi"
 )
 
-// The CRUD interface MUST be implemented in order to use the api2go api.
-// Use Responder for success status codes and content/meta data. In case of an error,
-// use the error return value preferrably with an instance of our HTTPError struct.
-type CRUD interface {
+type CRUDFindOne interface {
 	// FindOne returns an object by its ID
 	// Possible Responder success status code 200
 	FindOne(ID string, req Request) (Responder, error)
+}
 
+type CRUDCreate interface {
 	// Create a new object. Newly created object/struct must be in Responder.
 	// Possible Responder status codes are:
 	// - 201 Created: Resource was created and needs to be returned
@@ -21,14 +20,20 @@ type CRUD interface {
 	// - 204 No Content: Resource created with a client generated ID, and no fields were modified by
 	//   the server
 	Create(obj interface{}, req Request) (Responder, error)
+}
 
+type CRUDDelete interface {
 	// Delete an object
 	// Possible Responder status codes are:
 	// - 200 OK: Deletion was a success, returns meta information, currently not implemented! Do not use this
 	// - 202 Accepted: Processing is delayed, return nothing
 	// - 204 No Content: Deletion was successful, return nothing
 	Delete(id string, req Request) (Responder, error)
+}
 
+type CRUDUpdate interface {
+	// CRUDFindOne must be implemented along with CRUDUpdate so that api2go can retrieve the single resource before update
+	CRUDFindOne
 	// Update an object
 	// Possible Responder status codes are:
 	// - 200 OK: Update successful, however some field(s) were changed, returns updates source

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -6,12 +6,14 @@ import (
 	"github.com/manyminds/api2go/jsonapi"
 )
 
+// The CRUDFindOne interface MUST be implemented in order to generate the single GET route and related
 type CRUDFindOne interface {
 	// FindOne returns an object by its ID
 	// Possible Responder success status code 200
 	FindOne(ID string, req Request) (Responder, error)
 }
 
+// The CRUDCreate interface MUST be implemented in order to generate the POST route
 type CRUDCreate interface {
 	// Create a new object. Newly created object/struct must be in Responder.
 	// Possible Responder status codes are:
@@ -22,6 +24,7 @@ type CRUDCreate interface {
 	Create(obj interface{}, req Request) (Responder, error)
 }
 
+// The CRUDDelete interface MUST be implemented in order to generate the DELETE route
 type CRUDDelete interface {
 	// Delete an object
 	// Possible Responder status codes are:
@@ -31,6 +34,7 @@ type CRUDDelete interface {
 	Delete(id string, req Request) (Responder, error)
 }
 
+// The CRUDUpdate interface MUST be implemented in order to generate the PATCH/PUT routes
 type CRUDUpdate interface {
 	// CRUDFindOne must be implemented along with CRUDUpdate so that api2go can retrieve the single resource before update
 	CRUDFindOne

--- a/api_interfaces.go
+++ b/api_interfaces.go
@@ -6,15 +6,15 @@ import (
 	"github.com/manyminds/api2go/jsonapi"
 )
 
-// The CRUDFindOne interface MUST be implemented in order to generate the single GET route and related
-type CRUDFindOne interface {
+// The ResourceGetter interface MUST be implemented in order to generate the single GET route and related
+type ResourceGetter interface {
 	// FindOne returns an object by its ID
 	// Possible Responder success status code 200
 	FindOne(ID string, req Request) (Responder, error)
 }
 
-// The CRUDCreate interface MUST be implemented in order to generate the POST route
-type CRUDCreate interface {
+// The ResourceCreator interface MUST be implemented in order to generate the POST route
+type ResourceCreator interface {
 	// Create a new object. Newly created object/struct must be in Responder.
 	// Possible Responder status codes are:
 	// - 201 Created: Resource was created and needs to be returned
@@ -24,8 +24,8 @@ type CRUDCreate interface {
 	Create(obj interface{}, req Request) (Responder, error)
 }
 
-// The CRUDDelete interface MUST be implemented in order to generate the DELETE route
-type CRUDDelete interface {
+// The ResourceDeleter interface MUST be implemented in order to generate the DELETE route
+type ResourceDeleter interface {
 	// Delete an object
 	// Possible Responder status codes are:
 	// - 200 OK: Deletion was a success, returns meta information, currently not implemented! Do not use this
@@ -34,10 +34,10 @@ type CRUDDelete interface {
 	Delete(id string, req Request) (Responder, error)
 }
 
-// The CRUDUpdate interface MUST be implemented in order to generate the PATCH/PUT routes
-type CRUDUpdate interface {
-	// CRUDFindOne must be implemented along with CRUDUpdate so that api2go can retrieve the single resource before update
-	CRUDFindOne
+// The ResourceUpdater interface MUST be implemented in order to generate the PATCH/PUT routes
+type ResourceUpdater interface {
+	// ResourceGetter must be implemented along with ResourceUpdater so that api2go can retrieve the single resource before update
+	ResourceGetter
 	// Update an object
 	// Possible Responder status codes are:
 	// - 200 OK: Update successful, however some field(s) were changed, returns updates source

--- a/api_interfaces_test.go
+++ b/api_interfaces_test.go
@@ -80,6 +80,34 @@ func (s SomeResource) Update(obj interface{}, req Request) (Responder, error) {
 	}
 }
 
+type ResourceReadOnly struct{}
+
+func (r ResourceReadOnly) FindOne(ID string, req Request) (Responder, error) {
+	return &Response{Res: SomeData{ID: "12345", Data: "A Brezzn"}, Code: http.StatusOK}, nil
+}
+
+type ResourceCreationOnly struct{}
+
+func (r ResourceCreationOnly) Create(obj interface{}, req Request) (Responder, error) {
+	return &Response{Res: SomeData{ID: "12345", Data: "A Brezzn"}, Code: http.StatusCreated}, nil
+}
+
+type ResourceUpdateOnly struct{}
+
+func (r ResourceUpdateOnly) FindOne(ID string, req Request) (Responder, error) {
+	return &Response{Res: SomeData{ID: "12345", Data: "A Brezzn"}, Code: http.StatusOK}, nil
+}
+
+func (r ResourceUpdateOnly) Update(obj interface{}, req Request) (Responder, error) {
+	return &Response{Res: SomeData{ID: "12345", Data: "A Brezzn"}, Code: http.StatusOK}, nil
+}
+
+type ResourceDeletionOnly struct{}
+
+func (r ResourceDeletionOnly) Delete(id string, req Request) (Responder, error) {
+	return &Response{Code: http.StatusNoContent}, nil
+}
+
 var _ = Describe("Test interface api type casting", func() {
 	var (
 		api *API
@@ -267,6 +295,166 @@ var _ = Describe("Test return code behavior", func() {
 			delete("204")
 			Expect(rec.Code).To(Equal(http.StatusNoContent))
 			Expect(rec.Body.String()).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("Test partial CRUD implementation : Creator", func() {
+	var (
+		api                *API
+		rec                *httptest.ResponseRecorder
+		payload, payloadID SomeData
+	)
+
+	BeforeEach(func() {
+		api = NewAPI("v1")
+		api.AddResource(SomeData{}, ResourceCreationOnly{})
+		rec = httptest.NewRecorder()
+		payloadID = SomeData{ID: "12345", Data: "A Brezzn"}
+		payload = SomeData{Data: "A Brezzn"}
+	})
+
+	Context("Create", func() {
+		post := func(payload SomeData) {
+			m, err := jsonapi.Marshal(payload)
+			Expect(err).ToNot(HaveOccurred())
+			req, err := http.NewRequest("POST", "/v1/someDatas", strings.NewReader(string(m)))
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+		}
+
+		It("returns 201", func() {
+			post(payload)
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+			var actual SomeData
+			err := jsonapi.Unmarshal(rec.Body.Bytes(), &actual)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(payloadID).To(Equal(actual))
+		})
+
+		It("returns 404 on every other routes", func() {
+			// Test PATCH
+			m, err := jsonapi.Marshal(payload)
+			Expect(err).ToNot(HaveOccurred())
+			reqPatch, errPatch := http.NewRequest("PATCH", "/v1/someDatas/12345", strings.NewReader(string(m)))
+			Expect(errPatch).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqPatch)
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+			// Test DELETE
+			reqDelete, errDelete := http.NewRequest("DELETE", "/v1/someDatas/12345", nil)
+			Expect(errDelete).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqDelete)
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+			// Test GET item
+			reqRead, errRead := http.NewRequest("GET", "/v1/someDatas/12345", nil)
+			Expect(errRead).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqRead)
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+})
+
+var _ = Describe("Test partial CRUD implementation : Updater", func() {
+	var (
+		api                *API
+		rec                *httptest.ResponseRecorder
+		payload, payloadID SomeData
+	)
+
+	BeforeEach(func() {
+		api = NewAPI("v1")
+		api.AddResource(SomeData{}, ResourceUpdateOnly{})
+		rec = httptest.NewRecorder()
+		payloadID = SomeData{ID: "12345", Data: "A Brezzn"}
+		payload = SomeData{Data: "A Brezzn"}
+	})
+
+	Context("Update", func() {
+		patch := func(payload SomeData) {
+			m, err := jsonapi.Marshal(payload)
+			Expect(err).ToNot(HaveOccurred())
+			req, err := http.NewRequest("PATCH", "/v1/someDatas/12345", strings.NewReader(string(m)))
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+		}
+
+		It("returns 200", func() {
+			patch(SomeData{ID: "12345", Data: "override me"})
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			var actual SomeData
+			err := jsonapi.Unmarshal(rec.Body.Bytes(), &actual)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(payloadID).To(Equal(actual))
+		})
+
+		It("returns 404 on every other routes", func() {
+			// Test POST
+			m, err := jsonapi.Marshal(payload)
+			Expect(err).ToNot(HaveOccurred())
+			reqPost, errPost := http.NewRequest("POST", "/v1/someDatas", strings.NewReader(string(m)))
+			Expect(errPost).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqPost)
+			Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+			// Test DELETE
+			reqDelete, errDelete := http.NewRequest("DELETE", "/v1/someDatas/12345", nil)
+			Expect(errDelete).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqDelete)
+			Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+			// Test GET item
+			reqRead, errRead := http.NewRequest("GET", "/v1/someDatas/12345", nil)
+			Expect(errRead).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqRead)
+			Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+		})
+
+	})
+})
+
+var _ = Describe("Test partial CRUD implementation : Deleter", func() {
+	var (
+		api                *API
+		rec                *httptest.ResponseRecorder
+		payload, payloadID SomeData
+	)
+
+	BeforeEach(func() {
+		api = NewAPI("v1")
+		api.AddResource(SomeData{}, ResourceDeletionOnly{})
+		rec = httptest.NewRecorder()
+		payloadID = SomeData{ID: "12345", Data: "A Brezzn"}
+		payload = SomeData{Data: "A Brezzn"}
+	})
+
+	Context("Delete", func() {
+		delete := func() {
+			req, err := http.NewRequest("DELETE", "/v1/someDatas/1234", nil)
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+		}
+
+		It("returns 204", func() {
+			delete()
+			Expect(rec.Code).To(Equal(http.StatusNoContent))
+		})
+
+		It("returns 404 on every other routes", func() {
+			// Test POST
+			m, err := jsonapi.Marshal(payload)
+			Expect(err).ToNot(HaveOccurred())
+			reqPost, errPost := http.NewRequest("POST", "/v1/someDatas", strings.NewReader(string(m)))
+			Expect(errPost).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqPost)
+			Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+			// Test PATCH
+			reqPatch, errPatch := http.NewRequest("PATCH", "/v1/someDatas/12345", strings.NewReader(string(m)))
+			Expect(errPatch).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqPatch)
+			Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+			// Test GET item
+			reqRead, errRead := http.NewRequest("GET", "/v1/someDatas/12345", nil)
+			Expect(errRead).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, reqRead)
+			Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
 		})
 	})
 })

--- a/api_public.go
+++ b/api_public.go
@@ -42,7 +42,7 @@ func (api *API) SetContextAllocator(allocator APIContextAllocatorFunc) {
 // At least the CRUD interface must be implemented, all the other interfaces are optional.
 // `resource` should be either an empty struct instance such as `Post{}` or a pointer to
 // a struct such as `&Post{}`. The same type will be used for constructing new elements.
-func (api *API) AddResource(prototype jsonapi.MarshalIdentifier, source CRUD) {
+func (api *API) AddResource(prototype jsonapi.MarshalIdentifier, source interface{}) {
 	api.addResource(prototype, source)
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -819,7 +819,12 @@ var _ = Describe("RestHandler", func() {
 			api.Handler().ServeHTTP(rec, req)
 			Expect(err).To(BeNil())
 			Expect(rec.Code).To(Equal(http.StatusNoContent))
-			Expect(rec.Header().Get("Allow")).To(Equal("GET,POST,PATCH,OPTIONS"))
+			Expect(strings.Split(rec.Header().Get("Allow"), ",")).To(Equal([]string{
+				"OPTIONS",
+				"GET",
+				"PATCH",
+				"POST",
+			}))
 		})
 
 		It("OPTIONS on element route", func() {
@@ -827,7 +832,12 @@ var _ = Describe("RestHandler", func() {
 			api.Handler().ServeHTTP(rec, req)
 			Expect(err).To(BeNil())
 			Expect(rec.Code).To(Equal(http.StatusNoContent))
-			Expect(rec.Header().Get("Allow")).To(Equal("GET,PATCH,DELETE,OPTIONS"))
+			Expect(strings.Split(rec.Header().Get("Allow"), ",")).To(Equal([]string{
+				"OPTIONS",
+				"GET",
+				"PATCH",
+				"DELETE",
+			}))
 		})
 
 		It("DELETEs", func() {


### PR DESCRIPTION
Here is a first attempt to split the CRUD interface as mentioned in issue #267.

I really don't like typing the source with an empty interface but as the idea here is to be able to pass one implement of at least one of the new four interfaces, I can't see any other way to make it work.

Suprisingly, tests are passing seamlessly. I probably say surprisingly because I come from a inheritance-based language and composition in Go allows us to make smooth updates on interfaces (❤️). By the way, we do need to test the generated routes by passing several combinations of implementations of these CRUD interfaces.

Let me know what do you think about that !