### PR TITLE
Add easy way to combine multiple API versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go:
   - 1.7
+  - 1.8
+  - 1.9
   - tip
 
 sudo: false

--- a/api_public.go
+++ b/api_public.go
@@ -52,6 +52,13 @@ func (api *API) UseMiddleware(middleware ...HandlerFunc) {
 	api.middlewares = append(api.middlewares, middleware...)
 }
 
+// NewAPIVersion can be used to chain an additional API version to the routing of a previous
+// one. Use this if you have multiple version prefixes and want to combine all
+// your different API versions. This reuses the baseURL or URLResolver
+func (api *API) NewAPIVersion(prefix string) *API {
+	return newAPI(prefix, api.info.resolver, api.router)
+}
+
 // NewAPIWithResolver can be used to create an API with a custom URL resolver.
 func NewAPIWithResolver(prefix string, resolver URLResolver) *API {
 	handler := notAllowedHandler{}


### PR DESCRIPTION
Make it easy to add another version of an API to the routing of the first. This is fixing #290 