### PR TITLE
Support links with null values

### DIFF
--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -90,6 +90,9 @@ func (l *Link) UnmarshalJSON(payload []byte) error {
 // MarshalJSON returns the JSON encoding of only the Href field if the Meta
 // field is empty, otherwise it marshals the whole struct.
 func (l Link) MarshalJSON() ([]byte, error) {
+	if l.Empty() {
+		return json.Marshal(nil)
+	}
 	if len(l.Meta) == 0 {
 		return json.Marshal(l.Href)
 	}
@@ -99,43 +102,13 @@ func (l Link) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// empty returns true if the link has no href and no metadata.
-func (l Link) empty() bool {
+// Empty returns true if the link has no href and no metadata.
+func (l Link) Empty() bool {
 	return len(l.Meta) == 0 && l.Href == ""
 }
 
 // Links contains a map of custom Link objects as given by an element.
 type Links map[string]Link
-
-// MarshalJSON returns the JSON encoding of all links which contain any data.
-// Any links which had no href and no metadata will be omitted.
-func (l Links) MarshalJSON() ([]byte, error) {
-	links := make(map[string]Link)
-	for name, link := range l {
-		if !link.empty() {
-			links[name] = link
-		}
-	}
-
-	return json.Marshal(links)
-}
-
-// UnmarshalJSON decodes all links in the given payload onto the structure.
-// Any links which have no metadata and no href will be skipped.
-func (l Links) UnmarshalJSON(payload []byte) error {
-	links := make(map[string]Link)
-	if err := json.Unmarshal(payload, &links); err != nil {
-		return err
-	}
-
-	for name, link := range links {
-		if !link.empty() {
-			l[name] = link
-		}
-	}
-
-	return nil
-}
 
 // Meta contains unstructured metadata
 type Meta map[string]interface{}

--- a/jsonapi/data_structs_test.go
+++ b/jsonapi/data_structs_test.go
@@ -240,19 +240,4 @@ var _ = Describe("JSONAPI Struct tests", func() {
 			}
 		})
 	})
-
-	Context("Marshal and Unmarshal sets of links", func() {
-		It("unmarshals and excludes empty links", func() {
-			payload := []byte(`{"someLink":null,"otherLink":"hello"}`)
-			target := Links{}
-			expected := Links{
-				"otherLink": Link{
-					Href: "hello",
-				},
-			}
-			err := json.Unmarshal(payload, &target)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(target).To(Equal(expected))
-		})
-	})
 })

--- a/jsonapi/data_structs_test.go
+++ b/jsonapi/data_structs_test.go
@@ -208,6 +208,14 @@ var _ = Describe("JSONAPI Struct tests", func() {
 			Expect(target).To(Equal(expected))
 		})
 
+		It("unmarshals from null", func() {
+			expected := Link{}
+			target := Link{}
+			err := json.Unmarshal([]byte(`null`), &target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal(expected))
+		})
+
 		It("unmarshals with an error when href is missing", func() {
 			err := json.Unmarshal([]byte(`{}`), &Link{})
 			Expect(err).To(HaveOccurred())
@@ -224,12 +232,27 @@ var _ = Describe("JSONAPI Struct tests", func() {
 		})
 
 		It("unmarshals with an error for wrong types", func() {
-			badPayloads := []string{`null`, `13`, `[]`}
+			badPayloads := []string{`13`, `[]`}
 			for _, payload := range badPayloads {
 				err := json.Unmarshal([]byte(payload), &Link{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("expected a JSON encoded string or object"))
 			}
+		})
+	})
+
+	Context("Marshal and Unmarshal sets of links", func() {
+		It("unmarshals and excludes empty links", func() {
+			payload := []byte(`{"someLink":null,"otherLink":"hello"}`)
+			target := Links{}
+			expected := Links{
+				"otherLink": Link{
+					Href: "hello",
+				},
+			}
+			err := json.Unmarshal(payload, &target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal(expected))
 		})
 	})
 })

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -489,7 +489,8 @@ func (n CustomLinksPost) GetName() string {
 
 func (n CustomLinksPost) GetCustomLinks(base string) Links {
 	return Links{
-		"someLink": Link{Href: base + `/someLink`},
+		"nothingInHere": Link{},
+		"someLink":      Link{Href: base + `/someLink`},
 		"otherLink": Link{
 			Href: base + `/otherLink`,
 			Meta: Meta{

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -232,6 +232,7 @@ var _ = Describe("Marshalling", func() {
 					"id": "someID",
 					"attributes": {},
 					"links": {
+						"nothingInHere": null,
 						"someLink": "http://my.domain/v1/posts/someID/someLink",
 						"otherLink": {
 							"href": "http://my.domain/v1/posts/someID/otherLink",


### PR DESCRIPTION
I have an API which returns pagination links (`prev`, `next`, etc.) with null values if there is no previous or next page. I am using this library to write a Go client for it and noticed I started getting `expected a JSON encoded string or object` errors. At first I thought our API was wrong, but after a quick check of the spec, it turns out this actually is something JSONAPI-compliant clients should support.

On first read, the spec seems to contradict itself a bit. Here is bit from the [links element](http://jsonapi.org/format/#document-links), which states:

> The value of each links member MUST be an object (a “links object”).

And here is a quote from the [pagination section](http://jsonapi.org/format/#fetching-pagination):

> Keys MUST either be omitted or have a null value to indicate that a particular link is unavailable.

I think the best thing to do is probably to allow null link values by simply ignoring them, which is what this PR does. `Unmarshal` code paths will be able to simply check the `Links` object for presence of the link they are looking for, and `Marshal` code paths will continue to work. The only difference here would be that null links would simply not be included in the marshaled output, instead of returning a link object with an empty `href` and no `meta`.