### PR TITLE
Drop support for go 1.7 because of echo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
-  - tip
+  - "1.8"
+  - "1.9"
+  - "1.10"
+  - "tip"
 
 sudo: false
 


### PR DESCRIPTION
Echo dropped the support for go 1.7 which leads us
to either drop support for echo, or go 1.7. :/

That's also why https://github.com/manyminds/api2go/pull/313 fails.