### PR TITLE
Allow resources to specify meta using the new MarshalMeta interface

### DIFF
--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -120,13 +120,14 @@ type Data struct {
 	Attributes    json.RawMessage         `json:"attributes"`
 	Relationships map[string]Relationship `json:"relationships,omitempty"`
 	Links         Links                   `json:"links,omitempty"`
+	Meta          Meta                    `json:"meta,omitempty"`
 }
 
 // Relationship contains reference IDs to the related structs
 type Relationship struct {
 	Links Links                      `json:"links,omitempty"`
 	Data  *RelationshipDataContainer `json:"data,omitempty"`
-	Meta  map[string]interface{}     `json:"meta,omitempty"`
+	Meta  Meta                       `json:"meta,omitempty"`
 }
 
 // A RelationshipDataContainer is used to marshal and unmarshal single relationship

--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -120,14 +120,14 @@ type Data struct {
 	Attributes    json.RawMessage         `json:"attributes"`
 	Relationships map[string]Relationship `json:"relationships,omitempty"`
 	Links         Links                   `json:"links,omitempty"`
-	Meta          Meta                    `json:"meta,omitempty"`
+	Meta          json.RawMessage         `json:"meta,omitempty"`
 }
 
 // Relationship contains reference IDs to the related structs
 type Relationship struct {
 	Links Links                      `json:"links,omitempty"`
 	Data  *RelationshipDataContainer `json:"data,omitempty"`
-	Meta  Meta                       `json:"meta,omitempty"`
+	Meta  map[string]interface{}     `json:"meta,omitempty"`
 }
 
 // A RelationshipDataContainer is used to marshal and unmarshal single relationship

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -514,7 +514,7 @@ func (n CustomResourceMetaPost) GetName() string {
 	return "posts"
 }
 
-func (n CustomResourceMetaPost) GetMeta() Meta {
+func (n CustomResourceMetaPost) Meta() Meta {
 	return Meta{"access_count": 15}
 }
 

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -500,6 +500,24 @@ func (n CustomLinksPost) GetCustomLinks(base string) Links {
 	}
 }
 
+type CustomResourceMetaPost struct{}
+
+func (n CustomResourceMetaPost) GetID() string {
+	return "someID"
+}
+
+func (n *CustomResourceMetaPost) SetID(ID string) error {
+	return nil
+}
+
+func (n CustomResourceMetaPost) GetName() string {
+	return "posts"
+}
+
+func (n CustomResourceMetaPost) GetMeta() Meta {
+	return Meta{"access_count": 15}
+}
+
 type CustomMetaPost struct{}
 
 func (n CustomMetaPost) GetID() string {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -80,6 +80,13 @@ type MarshalCustomLinks interface {
 	GetCustomLinks(string) Links
 }
 
+// The MarshalMeta interface can be implemented if the struct should
+// want any meta.
+type MarshalMeta interface {
+	MarshalIdentifier
+	GetMeta() Meta
+}
+
 // The MarshalCustomRelationshipMeta interface can be implemented if the struct should
 // want a custom meta in a relationship.
 type MarshalCustomRelationshipMeta interface {
@@ -252,6 +259,10 @@ func marshalData(element MarshalIdentifier, data *Data, information ServerInform
 				}
 			}
 		}
+	}
+
+	if meta, ok := element.(MarshalMeta); ok {
+		data.Meta = meta.GetMeta()
 	}
 
 	if references, ok := element.(MarshalLinkedRelations); ok {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -261,8 +261,12 @@ func marshalData(element MarshalIdentifier, data *Data, information ServerInform
 		}
 	}
 
-	if meta, ok := element.(MarshalMeta); ok {
-		data.Meta = meta.GetMeta()
+	if casteMetaTarget, ok := element.(MarshalMeta); ok {
+		meta := casteMetaTarget.GetMeta()
+		data.Meta, err = json.Marshal(meta)
+		if err != nil {
+			return err
+		}
 	}
 
 	if references, ok := element.(MarshalLinkedRelations); ok {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -84,7 +84,7 @@ type MarshalCustomLinks interface {
 // want any meta.
 type MarshalMeta interface {
 	MarshalIdentifier
-	GetMeta() Meta
+	Meta() Meta
 }
 
 // The MarshalCustomRelationshipMeta interface can be implemented if the struct should
@@ -262,7 +262,7 @@ func marshalData(element MarshalIdentifier, data *Data, information ServerInform
 	}
 
 	if casteMetaTarget, ok := element.(MarshalMeta); ok {
-		meta := casteMetaTarget.GetMeta()
+		meta := casteMetaTarget.Meta()
 		data.Meta, err = json.Marshal(meta)
 		if err != nil {
 			return err

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -271,6 +271,22 @@ var _ = Describe("Marshalling", func() {
 		})
 	})
 
+	Context("When marshaling objects with data meta", func() {
+		It("contains the meta in the marshaled data object", func() {
+			post := CustomResourceMetaPost{}
+			i, err := Marshal(post)
+			Expect(err).To(BeNil())
+			Expect(i).To(MatchJSON(`{
+				"data": {
+					"type": "posts",
+					"id": "someID",
+					"attributes": {},
+					"meta": { "access_count": 15 }
+				}
+			}`))
+		})
+	})
+
 	Context("When marshaling compound objects", func() {
 		It("marshals nested objects", func() {
 			comment1 := Comment{ID: 1, Text: "First!", SubCommentsEmpty: true}


### PR DESCRIPTION
As per the [jsonapi](http://jsonapi.org/format/#document-resource-objects) Resource Objects should be able to have "meta" member pointing to a "Meta Object"