### PR TITLE
Adding RouteNamer interface

### DIFF
--- a/api.go
+++ b/api.go
@@ -244,6 +244,12 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		return info
 	}
 
+	// check if EntityNamer interface is implemented and use that as name
+	routeName, ok := prototype.(jsonapi.RouteNamer)
+	if ok {
+		name = routeName.GetRouteName()
+	}
+
 	prefix := strings.Trim(api.info.prefix, "/")
 	baseURL := "/" + name
 	if prefix != "" {

--- a/jsonapi/route_namer.go
+++ b/jsonapi/route_namer.go
@@ -1,0 +1,9 @@
+package jsonapi
+
+// The RouteNamer interface can be optionally implemented to directly return the
+// name of route used for the "type" field.
+//
+// Note: By default the name is guessed from the struct name or from EntityNamer.
+type RouteNamer interface {
+	GetRouteName() string
+}


### PR DESCRIPTION
Using api2go I noticed you coupled the types with the route names, and I want to have singular types and plural routes. So I added a `RouteNamer` interface.  If you are willing to accept this I will be happy to update the docs too.