### PR TITLE
Add missing error checks to SetToOneReferenceID and SetToManyReferenceIDs calls

### DIFF
--- a/api.go
+++ b/api.go
@@ -1241,7 +1241,10 @@ func processRelationshipsData(data interface{}, linkName string, target interfac
 			return errors.New("target struct must implement interface UnmarshalToOneRelations")
 		}
 
-		target.SetToOneReferenceID(linkName, hasOneID)
+		err := target.SetToOneReferenceID(linkName, hasOneID)
+		if err != nil {
+			return err
+		}
 	} else if data == nil {
 		// this means that a to-one relationship must be deleted
 		target, ok := target.(jsonapi.UnmarshalToOneRelations)
@@ -1249,7 +1252,10 @@ func processRelationshipsData(data interface{}, linkName string, target interfac
 			return errors.New("target struct must implement interface UnmarshalToOneRelations")
 		}
 
-		target.SetToOneReferenceID(linkName, "")
+		err := target.SetToOneReferenceID(linkName, "")
+		if err != nil {
+			return err
+		}
 	} else {
 		hasMany, ok := data.([]interface{})
 		if !ok {
@@ -1276,7 +1282,10 @@ func processRelationshipsData(data interface{}, linkName string, target interfac
 			hasManyIDs = append(hasManyIDs, dataID)
 		}
 
-		target.SetToManyReferenceIDs(linkName, hasManyIDs)
+		err := target.SetToManyReferenceIDs(linkName, hasManyIDs)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -174,11 +174,14 @@ func (c Post) GetReferences() []Reference {
 
 func (c *Post) SetToOneReferenceID(name, ID string) error {
 	if name == "author" {
-		intID, err := strconv.ParseInt(ID, 10, 64)
-		if err != nil {
-			return err
+		// Ignore empty author relationships
+		if ID != "" {
+			intID, err := strconv.ParseInt(ID, 10, 64)
+			if err != nil {
+				return err
+			}
+			c.AuthorID = sql.NullInt64{Valid: true, Int64: intID}
 		}
-		c.AuthorID = sql.NullInt64{Valid: true, Int64: intID}
 
 		return nil
 	}

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -187,7 +187,10 @@ func setRelationshipIDs(relationships map[string]Relationship, target UnmarshalI
 				return fmt.Errorf("struct %s does not implement UnmarshalToOneRelations", reflect.TypeOf(target))
 			}
 
-			castedToOne.SetToOneReferenceID(name, "")
+			err := castedToOne.SetToOneReferenceID(name, "")
+			if err != nil {
+				return err
+			}
 			continue
 		}
 

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -480,6 +480,28 @@ var _ = Describe("Unmarshal", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("this never works"))
 			})
+
+			datalessPostJSON := []byte(`{
+				"data": {
+					"id":   "3",
+					"type": "posts",
+					"attributes": {
+						"title": "Test"
+					},
+					"relationships": {
+						"author": {
+							"data": null
+						}
+					}
+				}
+			}`)
+
+			It("returns an error if SetToOneReferenceID returned an error, even for a relationship without a data field", func() {
+				post := ErrorRelationshipPosts{}
+				err := Unmarshal(datalessPostJSON, &post)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("this never works"))
+			})
 		})
 
 		Context("UnmarshalToManyRelations error handling", func() {


### PR DESCRIPTION
This PR fixes some instances where these methods are being called but their errors are not being checked. Also adds a test in the jsonapi library for this behavior and fixes the behavior of a fixture that used to return an error that was ignored.