### PR TITLE
Add local id support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/manyminds/api2go
 
+go 1.14
+
 require (
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
 	github.com/gin-gonic/gin v1.4.0

--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -117,6 +117,7 @@ type Meta map[string]interface{}
 type Data struct {
 	Type          string                  `json:"type"`
 	ID            string                  `json:"id"`
+	LID           string                  `json:"lid,omitempty"`
 	Attributes    json.RawMessage         `json:"attributes"`
 	Relationships map[string]Relationship `json:"relationships,omitempty"`
 	Links         Links                   `json:"links,omitempty"`
@@ -166,4 +167,5 @@ func (c *RelationshipDataContainer) MarshalJSON() ([]byte, error) {
 type RelationshipData struct {
 	Type string `json:"type"`
 	ID   string `json:"id"`
+	LID  string `json:"lid,omitempty"`
 }

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -28,10 +28,18 @@ type MarshalIdentifier interface {
 	GetID() string
 }
 
+// The MarshalLocalIdentifier interface is necessary to give an element a unique LID.
+//
+// Note: The implementation of this interface is mandatory.
+type MarshalLocalIdentifier interface {
+	GetLID() string
+}
+
 // ReferenceID contains all necessary information in order to reference another
 // struct in JSON API.
 type ReferenceID struct {
 	ID           string
+	LID          string
 	Type         string
 	Name         string
 	Relationship RelationshipType
@@ -245,6 +253,9 @@ func marshalData(element MarshalIdentifier, data *Data, information ServerInform
 
 	data.Attributes = attributes
 	data.ID = element.GetID()
+	if included, ok := element.(MarshalLocalIdentifier); ok {
+		data.LID = included.GetLID()
+	}
 	data.Type = getStructType(element)
 
 	if information != nil {
@@ -327,12 +338,14 @@ func getStructRelationships(relationer MarshalLinkedRelations, information Serve
 				container.DataArray = append(container.DataArray, RelationshipData{
 					Type: referenceID.Type,
 					ID:   referenceID.ID,
+					LID:  referenceID.LID,
 				})
 			}
 		} else {
 			container.DataObject = &RelationshipData{
 				Type: referenceIDs[0].Type,
 				ID:   referenceIDs[0].ID,
+				LID:  referenceIDs[0].LID,
 			}
 		}
 


### PR DESCRIPTION
Upcoming version of the JSONAPI (1.1) has a local id feature. Local
id or lid is a object identifier is used when id is missing along
with a type of the object.