### PR TITLE
Adding initial support for the meta field inside of data containers

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -2,6 +2,7 @@ package jsonapi
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -675,4 +676,13 @@ func (d DeepDedendencies) GetReferencedStructs() []MarshalIdentifier {
 	}
 
 	return structs
+}
+
+type SimplePostWithMetadata struct {
+	SimplePost
+	ResourceMetadata map[string]interface{}
+}
+
+func (p *SimplePostWithMetadata) SetResourceMeta(r json.RawMessage) error {
+	return json.Unmarshal(r, &p.ResourceMetadata)
 }

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -25,6 +25,12 @@ type UnmarshalToManyRelations interface {
 	SetToManyReferenceIDs(name string, IDs []string) error
 }
 
+// The UnmarshalResourceMeta interface must be implemented to unmarshal meta fields inside of data containers
+type UnmarshalResourceMeta interface {
+	MarshalIdentifier
+	SetResourceMeta(json.RawMessage) error
+}
+
 // The EditToManyRelations interface can be optionally implemented to add and
 // delete to-many relationships on a already unmarshalled struct. These methods
 // are used by our API for the to-many relationship update routes.
@@ -171,6 +177,15 @@ func setDataIntoTarget(data *Data, target interface{}) error {
 
 	if err := castedTarget.SetID(data.ID); err != nil {
 		return err
+	}
+
+	if data.Meta != nil {
+		if m, ok := target.(UnmarshalResourceMeta); ok {
+			err = m.SetResourceMeta(data.Meta)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return setRelationshipIDs(data.Relationships, castedTarget)

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -769,4 +769,40 @@ var _ = Describe("Unmarshal", func() {
 			Expect(target.Today.Valid).To(Equal(false))
 		})
 	})
+
+	Context("when unmarshaling resources with meta", func() {
+		It("unmarshal resource level meta", func() {
+			expectedPost := SimplePostWithMetadata{
+				SimplePost: SimplePost{
+					ID:    "1",
+					Title: "First Post",
+					Text:  "Lipsum",
+				},
+				ResourceMetadata: map[string]interface{}{
+					"user-agent": "Lorem ipsum 1.0",
+					"post-count": 10.0,
+				},
+			}
+			postJSON := []byte(`{
+			"data": {
+				"id": "1",
+				"type": "simplePostWithMetadatas",
+				"meta": {
+					"user-agent": "Lorem ipsum 1.0",
+					"post-count": 10
+				},
+				"attributes": {
+					"title": "First Post",
+					"text": "Lipsum"
+				}
+			}
+		}`)
+			var simplePostWithMetadata SimplePostWithMetadata
+			err := Unmarshal(postJSON, &simplePostWithMetadata)
+			Expect(err).To(BeNil())
+			Expect(expectedPost.SimplePost).To(Equal(simplePostWithMetadata.SimplePost))
+			Expect(expectedPost.ResourceMetadata["user-agent"]).To(Equal(simplePostWithMetadata.ResourceMetadata["user-agent"]))
+			Expect(expectedPost.ResourceMetadata["post-count"]).To(Equal(simplePostWithMetadata.ResourceMetadata["post-count"]))
+		})
+	})
 })


### PR DESCRIPTION
We noticed that the meta field was supported on the marshal side of things on the resource level, but was missing on the unmarshal side.

This PR adds a new interface:
```
type UnmarshalResourceMeta interface {
	MarshalIdentifier
	SetResourceMeta(json.RawMessage) error
}
```

The `UnmarshalResourceMeta` allows you to unmarshal the meta field when it's included on the resource object

Let me know what you think