### PR TITLE
Fix double-slash in front of pagination links with gingonic router adapter

### DIFF
--- a/api.go
+++ b/api.go
@@ -77,7 +77,7 @@ func (p paginationQueryParams) getLinks(r *http.Request, count uint, info inform
 
 	params := r.URL.Query()
 	prefix := ""
-	baseURL := info.GetBaseURL()
+	baseURL := strings.Trim(info.GetBaseURL(), "/")
 	if baseURL != "" {
 		prefix = baseURL
 	}


### PR DESCRIPTION
When initializing the api as

```golang
api := api2go.NewAPIWithRouting(
  "v1",
  api2go.NewStaticResolver("/"),
  routing.Gin(router),
)
```

the top-level `links` in paginated result sets look like this:

```json
"links": {
  "first": "//v1/items?page[limit]=4&page[offset]=0",
  "last": "//v1/items?page[limit]=4&page[offset]=223",
  "next": "//v1/items?page[limit]=4&page[offset]=14",
  "prev": "//v1/items?page[limit]=4&page[offset]=6"
},
```

this PR fixes this by trimming the `baseURL` in `paginationQueryParams.getLinks` in the same fashion as `resource.respondWith` does it with the `objWithLinks`.

It's possible to work around this by using

```golang
api2go.NewStaticResolver("")
```

but that didn't feel quite right.